### PR TITLE
Add .appveyor.yml for windows CI (#98)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,22 @@
+# clone directory
+clone_folder: c:\projects\ffig
+
+install:
+  - set PATH="C:\Program Files\LLVM\bin";%PATH%
+  - git submodule update --init
+  - C:\Python36-x64\python -m pip install jinja2 nose
+
+# scripts to run before build
+before_build:
+  - cd c:\projects\ffig
+  - echo Running cmake...
+  - cmake . -G "Visual Studio 14 2015 Win64" -DPYTHON_EXECUTABLE="C:\\Python36-x64\\python"
+
+configuration: Debug
+
+build:
+  project: test_ffig.sln
+
+after_build:
+  - ctest . -C Debug --output-on-failure
+

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Install Xcode. FFIG will use the version of libclang distributed with Xcode.
 
 # Setup (Windows)
 
-Untested, minor issues expected.
+Work in progress, minor issues expected.
 
 
 ## Submodules


### PR DESCRIPTION
https://www.appveyor.com will give us free Windows CI.
Issues with the python build script resolved by using CMake/CTest directly.
Needs Python 3.6 due to hang in libclang/ctypes. Only LLVM-64 bit is installed on appveyor.