### PR TITLE
Generators

### DIFF
--- a/ffig/FFIG.py
+++ b/ffig/FFIG.py
@@ -15,6 +15,7 @@ import sys
 
 import cppmodel
 import filters.capi_filter
+import generators
 
 if sys.platform == 'darwin':
     # OS X doesn't use DYLD_LIBRARY_PATH if System Integrity Protection is
@@ -44,25 +45,9 @@ def collect_api_and_obj_classes(classes, api_annotation):
 
     return [c for k, c in api_classes.items()]
 
-def render_api_and_obj_classes(api_classes, template):
-    s = ""
-    for c in api_classes:
-        s += str(template.render({"class": c.api_class, "impl_classes": c.impls}))
-    return s
-
 def get_class_name(header_path):
     header_name = os.path.basename(header_path)
     return re.sub(".h$", "", header_name)
-
-def get_template_name(template_path):
-    template_name = os.path.basename(template_path)
-    return re.sub(".tmpl$", "", template_name)
-
-def get_template_output(class_name, template_name):
-    split_name = template_name.split('.')
-    suffix_name = '.'.join(split_name[:-1])
-    extension = split_name[-1]
-    return "{}{}.{}".format(class_name, suffix_name, extension)
 
 def write_bindings_to_disk(api_classes, env, args, output_dir):
     """ 
@@ -74,10 +59,7 @@ def write_bindings_to_disk(api_classes, env, args, output_dir):
     - output_dir where to write to
     """
     for binding in args.bindings:
-        with open(os.path.join(output_dir, get_template_output(args.module_name, get_template_name(binding))), "w") as output_file:
-            template = env.get_template(binding)
-            output_string = render_api_and_obj_classes(api_classes, template)
-            output_file.write(output_string)
+        generators.generate(binding, api_classes, env, args, output_dir)
 
 def build_model_from_source(path_to_source, module_name):
     """

--- a/ffig/generators/__init__.py
+++ b/ffig/generators/__init__.py
@@ -120,12 +120,15 @@ def _scan_plugins():
     excluded_files = ['__init__.py', '__pycache__']
     for entry in os.listdir(basedir):
         log.info('Checking {}'.format(entry))
+        if entry in excluded_files:
+            log.info('Skipping excluded file {}'.format(entry))
+            continue
         filepath = os.path.join(basedir, entry)
         if os.path.isdir(filepath):
             log.info('Found plugin package {}'.format(entry))
             # This is a generator package. Import it.
             _activate_plugin(os.path.basename(entry))
-        elif os.path.isfile(filepath) and entry.endswith('.py') and entry not in excluded_files:
+        elif os.path.isfile(filepath) and entry.endswith('.py'):
             log.info('Found plugin module {}'.format(entry))
             _activate_plugin(os.path.basename(entry)[:-3])
 

--- a/ffig/generators/__init__.py
+++ b/ffig/generators/__init__.py
@@ -117,6 +117,7 @@ def _scan_plugins():
     '''
     basedir = os.path.realpath(os.path.dirname(__file__))
     log.info('Scanning for plugins in {}'.format(basedir))
+    excluded_files = ['__init__.py', '__pycache__.py']
     for entry in os.listdir(basedir):
         log.info('Checking {}'.format(entry))
         filepath = os.path.join(basedir, entry)
@@ -124,7 +125,7 @@ def _scan_plugins():
             log.info('Found plugin package {}'.format(entry))
             # This is a generator package. Import it.
             _activate_plugin(os.path.basename(entry))
-        elif os.path.isfile(filepath) and entry.endswith('.py') and entry != '__init__.py':
+        elif os.path.isfile(filepath) and entry.endswith('.py') and entry not in excluded_files:
             log.info('Found plugin module {}'.format(entry))
             _activate_plugin(os.path.basename(entry)[:-3])
 

--- a/ffig/generators/__init__.py
+++ b/ffig/generators/__init__.py
@@ -1,0 +1,132 @@
+import importlib
+import logging
+import os
+import os.path
+import re
+
+logging.basicConfig()
+log = logging.getLogger(__name__)
+log.setLevel(logging.WARNING)
+
+def render_api_and_obj_classes(api_classes, template):
+    '''Render a template.'''
+    s = ""
+    for c in api_classes:
+        s += str(template.render({"class": c.api_class, "impl_classes": c.impls}))
+    return s
+
+def get_template_name(template_path):
+    '''Get the template name from the binding name.'''
+    template_name = os.path.basename(template_path)
+    return re.sub(".tmpl$", "", template_name)
+
+def get_template_output(class_name, template_name):
+    '''Determine the output filename from the template name.'''
+    split_name = template_name.split('.')
+    suffix_name = '.'.join(split_name[:-1])
+    extension = split_name[-1]
+    return "{}{}.{}".format(class_name, suffix_name, extension)
+
+def default_generator(binding, api_classes, env, args, output_dir):
+    '''
+    Default generator.
+
+    Used when there are no custom generators registered for a binding. This
+    generator is appropriate for simple bindings that produce a single output
+    file.
+
+    Input:
+     - binding: The name of the binding to generate.
+     - api_classes: The classes to generate bindings for.
+     - env: The jinja2 environment.
+     - args: ffig arguments.
+     - output_dir: The base directory for generator output.
+    '''
+    output_file_name = os.path.join(output_dir,
+            get_template_output(args.module_name, get_template_name(binding)))
+    with open(output_file_name, 'w') as output_file:
+        template = env.get_template(binding)
+        output_string = render_api_and_obj_classes(api_classes, template)
+        output_file.write(output_string)
+    return output_file_name
+
+class GeneratorContext(object):
+    '''Holds a mapping of bindings to custom generators.'''
+    def __init__(self):
+        '''Initialise with no custom generators'''
+        self._generator_map = { }
+
+    def register(self, generator_function, bindings):
+        '''
+        Register a generation function.
+
+        Input:
+         - generator_function: f(binding, api_classes, env, args, output_dir).
+         - bindings: List of bindings that this function generates.
+        '''
+        for binding in bindings:
+            self._generator_map[binding] = generator_function
+
+    def generate(self, binding, api_classes, env, args, output_dir):
+        '''
+        Generate a set of bindings.
+
+        Input:
+          - binding: The type of binding to generate.
+          - api_classes: Classes to generate bindings for.
+          - env: The template environment.
+          - output_dir: Directory to write generated bindings to.
+        '''
+        log.info('Finding generator for {}'.format(binding))
+        if binding in self._generator_map:
+            log.info('  found in map')
+            return self._generator_map[binding](binding, api_classes, env, args, output_dir)
+        else:
+            log.info('  using default')
+            return default_generator(binding, api_classes, env, args, output_dir)
+
+# This is the default generator context.
+generator_context = GeneratorContext()
+
+def generate(binding, api_classes, env, args, output_dir):
+    '''Forward the request to the default generator context.'''
+    return generator_context.generate(binding, api_classes, env, args, output_dir)
+
+def _activate_plugin(module_name):
+    '''Internal function used to activate a plugin that has been found.'''
+    log.info('Importing {}'.format(module_name))
+    module = __import__('generators.{0}'.format(module_name), fromlist=['setup_plugin'])
+    module.setup_plugin(generator_context)
+
+def _scan_plugins():
+    ''' Internal function used to search the generators directory for plugins.
+
+        Plugins may be written as a module (a single python file in the
+        generators directory) or as a package (a subdirectory of generators,
+        containing an __init__.py).
+
+        In either case, plugins must define a function to register one or more
+        generator functions against a list of one or more binding names:
+        
+            def setup_plugin(context):
+                context.register(generator_func, [binding, ...])
+        
+        where generator_func is a function of the form
+
+            f(binding, api_classes, env, args, output_dir)
+    '''
+    basedir = os.path.realpath(os.path.dirname(__file__))
+    log.info('Scanning for plugins in {}'.format(basedir))
+    for entry in os.listdir(basedir):
+        log.info('Checking {}'.format(entry))
+        filepath = os.path.join(basedir, entry)
+        if os.path.isdir(filepath):
+            log.info('Found plugin package {}'.format(entry))
+            # This is a generator package. Import it.
+            _activate_plugin(os.path.basename(entry))
+        elif os.path.isfile(filepath) and entry.endswith('.py') and entry != '__init__.py':
+            log.info('Found plugin module {}'.format(entry))
+            _activate_plugin(os.path.basename(entry)[:-3])
+
+# Scan the generators directory for plugins and register them on initialisation.
+_scan_plugins()

--- a/ffig/generators/__init__.py
+++ b/ffig/generators/__init__.py
@@ -117,7 +117,7 @@ def _scan_plugins():
     '''
     basedir = os.path.realpath(os.path.dirname(__file__))
     log.info('Scanning for plugins in {}'.format(basedir))
-    excluded_files = ['__init__.py', '__pycache__.py']
+    excluded_files = ['__init__.py', '__pycache__']
     for entry in os.listdir(basedir):
         log.info('Checking {}'.format(entry))
         filepath = os.path.join(basedir, entry)

--- a/ffig/generators/go.py
+++ b/ffig/generators/go.py
@@ -1,0 +1,13 @@
+# Generator module for Golang.
+
+# Currently, this forwards to the default generator as an example / testcase
+# for generator plugins. Ultimately, it will generate Go packages in the
+# correct structure.
+
+import generators
+
+def go_generator(binding, api_classes, env, args, output_dir):
+    return generators.default_generator(binding, api_classes, env, args, output_dir)
+
+def setup_plugin(context):
+    context.register(go_generator, ['go.tmpl'])

--- a/ffig/generators/python/__init__.py
+++ b/ffig/generators/python/__init__.py
@@ -1,0 +1,6 @@
+from python2 import py2_generator
+from python3 import py3_generator
+
+def setup_plugin(context):
+    context.register(py2_generator, ['py.tmpl'])
+    context.register(py3_generator, ['py3.tmpl'])

--- a/ffig/generators/python/__init__.py
+++ b/ffig/generators/python/__init__.py
@@ -1,5 +1,5 @@
-from python2 import py2_generator
-from python3 import py3_generator
+from generators.python.python2 import py2_generator
+from generators.python.python3 import py3_generator
 
 def setup_plugin(context):
     context.register(py2_generator, ['py.tmpl'])

--- a/ffig/generators/python/python2.py
+++ b/ffig/generators/python/python2.py
@@ -1,0 +1,5 @@
+from generators import default_generator
+
+def py2_generator(binding, api_classes, env, args, output_dir):
+    default_generator(binding, api_classes, env, args, output_dir)
+

--- a/ffig/generators/python/python3.py
+++ b/ffig/generators/python/python3.py
@@ -1,0 +1,2 @@
+def py3_generator(binding, api_classes, env, args, output_dir):
+    raise Exception('Not implemented')


### PR DESCRIPTION
I'm sure I remember it being easier to get dynamic module imports to work. Last time I wanted to do a plugin arch. in Python it was fairly easy to import based on a filename. Oh well.

This moves the binding generation out of FFIG.py and into the generators sub-package. There's a default function (the existing impl. moved out of FFIG.py), and examples of a module-based generator (go.py) and a package-based generator (python/...). Both just forward their calls to the default generator, right now.