### PR TITLE
Don't import importlib

### DIFF
--- a/ffig/generators/__init__.py
+++ b/ffig/generators/__init__.py
@@ -1,4 +1,3 @@
-import importlib
 import logging
 import os
 import os.path


### PR DESCRIPTION
We're not using it. `__import__` worked better.