### PR TITLE
Produce a Go package from the Go generator.

### DIFF
--- a/cmake/ffig.cmake
+++ b/cmake/ffig.cmake
@@ -60,19 +60,10 @@ function(ffig_add_library)
     set(ffig_outputs "${ffig_outputs};${ffig_output_dir}/src/${module}/${module}.go")
   endif()
 
-  if(ffig_add_library_GO)
-    add_custom_command(OUTPUT ${ffig_outputs}
-      COMMAND ${PYTHON_EXECUTABLE} ffig/FFIG.py ${ffig_invocation}
-      COMMAND ${CMAKE_COMMAND} -E make_directory ${ffig_output_dir}/src/${module}
-      COMMAND ${CMAKE_COMMAND} -E rename ${ffig_output_dir}/${module}.go ${ffig_output_dir}/src/${module}/${module}.go
-      DEPENDS ${input}
-      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-  else()
-    add_custom_command(OUTPUT ${ffig_outputs}
-      COMMAND ${PYTHON_EXECUTABLE} ffig/FFIG.py ${ffig_invocation}
-      DEPENDS ${input}
-      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-  endif()
+  add_custom_command(OUTPUT ${ffig_outputs}
+    COMMAND ${PYTHON_EXECUTABLE} ffig/FFIG.py ${ffig_invocation}
+    DEPENDS ${input}
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
 
   # FIXME: This is a bit ugly. The header is copied next to the generated bindings.

--- a/ffig/FFIG.py
+++ b/ffig/FFIG.py
@@ -8,10 +8,13 @@ import argparse
 import clang
 import inspect
 import jinja2
+import logging
 import os
 import os.path
 import re
 import sys
+
+logging.basicConfig(level=logging.WARNING)
 
 import cppmodel
 import filters.capi_filter

--- a/ffig/generators/__init__.py
+++ b/ffig/generators/__init__.py
@@ -4,9 +4,7 @@ import os
 import os.path
 import re
 
-logging.basicConfig()
 log = logging.getLogger(__name__)
-log.setLevel(logging.WARNING)
 
 def render_api_and_obj_classes(api_classes, template):
     '''Render a template.'''
@@ -42,12 +40,14 @@ def default_generator(binding, api_classes, env, args, output_dir):
      - args: ffig arguments.
      - output_dir: The base directory for generator output.
     '''
+    template = env.get_template(binding)
+    output_string = render_api_and_obj_classes(api_classes, template)
+
     output_file_name = os.path.join(output_dir,
             get_template_output(args.module_name, get_template_name(binding)))
     with open(output_file_name, 'w') as output_file:
-        template = env.get_template(binding)
-        output_string = render_api_and_obj_classes(api_classes, template)
         output_file.write(output_string)
+
     return output_file_name
 
 class GeneratorContext(object):

--- a/ffig/generators/go.py
+++ b/ffig/generators/go.py
@@ -4,10 +4,39 @@
 # for generator plugins. Ultimately, it will generate Go packages in the
 # correct structure.
 
+import os
+import os.path
+
 import generators
+import logging
+
+log = logging.getLogger(__name__)
 
 def go_generator(binding, api_classes, env, args, output_dir):
-    return generators.default_generator(binding, api_classes, env, args, output_dir)
+    ''' Create Go bindings in an appropriate Go package.
+
+        This generator produces a directory src/modulename inside the output
+        directory, into which it writes a single Go file containing the
+        bindings for this module.
+    '''
+    module_directory = os.path.realpath(os.path.join(output_dir, 'src', args.module_name))
+    if not os.path.isdir(module_directory):
+        log.info('Creating Go package directory {}'.format(module_directory))
+        os.makedirs(module_directory)
+
+    log.info('Generating Go bindings for module {0}'.format(args.module_name))
+    template = env.get_template(binding)
+    generated_code = generators.render_api_and_obj_classes(api_classes, template)
+
+    output_file_name = os.path.join(module_directory,
+            generators.get_template_output(args.module_name,
+                generators.get_template_name(binding)))
+    with open(output_file_name, 'w') as f:
+        f.write(generated_code)
+        log.info('Wrote Go bindings for module {0} to {1}'.format(
+            args.module_name, output_file_name))
+
+    return output_file_name
 
 def setup_plugin(context):
     context.register(go_generator, ['go.tmpl'])


### PR DESCRIPTION
* The Go generator writes its output to src/${module}/${module}.go
  inside the output directory.

* The CMake file for ffig no longer special-cases Go generation, because
  the Go generator takes care of putting files in the right place.

* Logging has been set up throughout FFIG. ffig/FFIG.py sets up basic
  logging and defaults the log level to WARNING. Currently, only the
  generators package makes use of logging, but this allows us to use it
  more widely and keep the configuration consistent across the board.

* The default generator has been refactored to move the generation of
  the bindings string outside of the context in which the output file is
  opened. This reduces the scope in which the file is open, and fits
  better with a model where the generation and the production of files
  on disk may be disjointed (e.g. REST API).

Closes #132.