### PR TITLE
Support multiple paths for Xcode Command Line Tools.

### DIFF
--- a/ffig/FFIG.py
+++ b/ffig/FFIG.py
@@ -20,11 +20,21 @@ import cppmodel
 import filters.capi_filter
 import generators
 
+
+def find_clang_library_path():
+    paths = [
+        '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib',
+        '/Library/Developer/CommandLineTools/usr/lib',
+    ]
+    for path in paths:
+        if os.path.isfile(os.path.join(path, 'libclang.dylib')):
+            return path
+    raise Exception('Unable to find libclang.dylib')
+
 if sys.platform == 'darwin':
     # OS X doesn't use DYLD_LIBRARY_PATH if System Integrity Protection is
     # enabled. Set the library path for libclang manually.
-    clang.cindex.Config.set_library_path(
-        '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib')
+    clang.cindex.Config.set_library_path(find_clang_library_path())
 
 ffig_dir = os.path.abspath(os.path.dirname(__file__))
 

--- a/tests/cppmodel/util.py
+++ b/tests/cppmodel/util.py
@@ -4,12 +4,24 @@ from clang.cindex import Cursor
 from clang.cindex import TranslationUnit
 from clang.cindex import Config
 
+import os.path
 import sys
+
+
+def find_clang_library_path():
+    paths = [
+        '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib',
+        '/Library/Developer/CommandLineTools/usr/lib',
+    ]
+    for path in paths:
+        if os.path.isfile(os.path.join(path, 'libclang.dylib')):
+            return path
+    raise Exception('Unable to find libclang.dylib')
+
 if sys.platform == 'darwin':
     # OS X doesn't use DYLD_LIBRARY_PATH if System Integrity Protection is
     # enabled. Set the library path for libclang manually.
-    Config.set_library_path(
-        '/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib')
+    Config.set_library_path(find_clang_library_path())
 
 
 def get_tu(source, lang='c', all_warnings=False, flags=[]):


### PR DESCRIPTION
If only Xcode Command Line Tools are installed, they seem to go into a different place than when the full Xcode is installed.