### PR TITLE
N146: Use methods in Go bindings.

### DIFF
--- a/ffig/filters/capi_filter.py
+++ b/ffig/filters/capi_filter.py
@@ -51,7 +51,7 @@ def to_go(t):
         if t.pointee.kind == TypeKind.CHAR_S:
             return 'string'
         if t.pointee.kind == TypeKind.RECORD:
-            return 'unsafe.Pointer'
+            return t.pointee.name.replace('const', '')
     raise Exception('Type {} has no known Go equivalent'.format(t.name))
 
 
@@ -67,9 +67,26 @@ def to_go_convert(t):
             return 'unsafe.Pointer'
     raise Exception('Type {} has no known Go equivalent'.format(t.name))
 
+def to_go_method_name(m):
+    '''
+    Returns the method name with the first character uppercased.
+
+    In Go, only entities with an uppercase first character are exposed in the
+    module interface.
+    '''
+    return m.capitalize()
+
+def go_object(v, t):
+    '''
+    In analogy to the `c_object` filter below, this returns `v.ptr` for objects
+    of class type, and `v` for everything else.
+    '''
+    if t.kind == TypeKind.POINTER and t.pointee.kind == TypeKind.RECORD:
+        return '{}.ptr'.format(v)
+    else:
+        return v
+
 # C++ header filter to extract C type from C++ type
-
-
 def c_object(v, t):
     if t.kind == TypeKind.VOID:
         return v

--- a/ffig/filters/capi_filter.py
+++ b/ffig/filters/capi_filter.py
@@ -67,6 +67,7 @@ def to_go_convert(t):
             return 'unsafe.Pointer'
     raise Exception('Type {} has no known Go equivalent'.format(t.name))
 
+
 def to_go_method_name(m):
     '''
     Returns the method name with the first character uppercased.
@@ -75,6 +76,7 @@ def to_go_method_name(m):
     module interface.
     '''
     return m.capitalize()
+
 
 def go_object(v, t):
     '''
@@ -87,6 +89,8 @@ def go_object(v, t):
         return v
 
 # C++ header filter to extract C type from C++ type
+
+
 def c_object(v, t):
     if t.kind == TypeKind.VOID:
         return v

--- a/ffig/templates/go.tmpl
+++ b/ffig/templates/go.tmpl
@@ -41,9 +41,9 @@ func {{class.name}}_{{ impl.name }}_create({% for arg in method.arguments %}{{ar
 {% endfor %}
 
 {% for method in class.methods %}
-func {{class.name}}_{{method.name}}(my{{class.name}} {{class.name}}{% for arg in method.arguments %}, {{arg.name}} {{arg.type|to_go}}{% endfor %}) {% if not method.returns_void %}({{method.return_type|to_go}}, bool){% else %}bool{% endif %} {
+func (obj {{class.name}}) {{method.name|to_go_method_name}}({% for arg in method.arguments %}{{arg.name}} {{arg.type|to_go}}{% if not loop.last %},{% endif %}{% endfor %}) {% if not method.returns_void %}({{method.return_type|to_go}}, bool){% else %}bool{% endif %} {
     var rv C.RT_{{class.name}}_{{method.name}}
-    rv = C.CGo_{{class.name}}_{{method.name}}(my{{class.name}}.ptr{% for arg in method.arguments %}, {{arg.name}}{% endfor %})
+    rv = C.CGo_{{class.name}}_{{method.name}}(obj.ptr{% for arg in method.arguments %}, {{arg.name|go_object(arg.type)}}{% endfor %})
     
     if rv.status == 0 {
         {% if not method.returns_void %}

--- a/tests/go/Shape_test.go
+++ b/tests/go/Shape_test.go
@@ -8,18 +8,65 @@ import (
 
 const tolerance = 1e-11
 
-func Test_Circle(t *testing.T) {
-    s, err := Shape.AbstractShape_Circle_create(5.0)
+func Test_Circle_Area(t *testing.T) {
+    r := 5.0
+    s, err := Shape.AbstractShape_Circle_create(r)
     if (err) {
         t.Error(`Failed to create a Circle`)
     }
 
-    area, err := Shape.AbstractShape_area(s)
+    area, err := s.Area()
     if (err) {
-        t.Error(`Failed to call Shape.AbstractShape_area()`)
+        t.Error(`Failed to call Circle.Area()`)
     }
-    if math.Abs(area - (5.0 * 5.0 * math.Pi)) > tolerance {
-        t.Error(`Shape.AbstractShape_area() does not match expectation`)
+    if math.Abs(area - (math.Pi * r * r)) > tolerance {
+        t.Error(`Circle.Area() does not match expectation`)
     }
 }
 
+func Test_Circle_Perimeter(t *testing.T) {
+    r := 5.0
+    s, err := Shape.AbstractShape_Circle_create(r)
+    if (err) {
+        t.Error(`Failed to create a Circle`)
+    }
+
+    perim, err := s.Perimeter()
+    if (err) {
+        t.Error(`Failed to call Circle.Perimeter()`)
+    }
+    if math.Abs(perim - (2.0 * math.Pi * r)) > tolerance {
+        t.Error(`Circle.Perimeter() does not match expectation`)
+    }
+}
+
+func Test_Circle_Is_equal(t *testing.T) {
+    r := 5.0
+    s, err := Shape.AbstractShape_Circle_create(r)
+    if (err) {
+        t.Error(`Failed to create a Circle`)
+    }
+
+    s2, err := Shape.AbstractShape_Circle_create(r)
+    if (err) {
+        t.Error(`Failed to create a Circle`)
+    }
+
+    result, err := s.Is_equal(s2)
+    if (err) {
+        t.Error(`Failed to call Circle.Is_equal()`)
+    }
+    if result == 0 {
+        t.Error(`Circle.Is_equal() does not match expectation (expected non-zero)`)
+    }
+
+    s3, err := Shape.AbstractShape_Circle_create(2.0 * r)
+    if err {
+        t.Error(`Failed to create a Circle`)
+    }
+
+    result, err = s.Is_equal(s3)
+    if result != 0 {
+        t.Error(`Circle.Is_equal() does not match expectation (expected zero)`)
+    }
+}


### PR DESCRIPTION
Member functions of C++ types are now methods of Go types. Two additional filters have been added to facilitate this:

go_object(val, type):
    returns val.ptr for class types, or val for everything else. This is
    analogous to the c_object filter for the C++ bindings.

to_go_method_name(m):
    Returns the method name with the first character converted to
    uppercase, so that it is available as an exported method of the Go
    type.