### PR TITLE
Fall back on 'make' if 'ninja' isn't available.

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -5,6 +5,14 @@ import platform
 import shutil
 import subprocess
 
+def check_for_executable(exe_name, args=['--version']):
+    try:
+        cmd = [exe_name]
+        cmd.extend(args)
+        subprocess.check_output(cmd)
+        return True
+    except:
+        return False
 
 def main():
     import argparse
@@ -60,7 +68,10 @@ def main():
         else:
             cmake_invocation.extend(['-G', 'Visual Studio 14 2015 Win64'])
     else:
-        cmake_invocation.extend(['-GNinja', '-DCMAKE_BUILD_TYPE={}'.format(args.config)])
+        # Use Ninja instead of Make, if available.
+        if check_for_executable('ninja'):
+            cmake_invocation.extend(['-GNinja'])
+        cmake_invocation.extend(['-DCMAKE_BUILD_TYPE={}'.format(args.config)])
 
     if args.verbose:
         cmake_invocation.append('-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON')

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -11,7 +11,7 @@ def check_for_executable(exe_name, args=['--version']):
         cmd.extend(args)
         subprocess.check_output(cmd)
         return True
-    except:
+    except subprocess.CalledProcessError:
         return False
 
 def main():

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -5,6 +5,7 @@ import platform
 import shutil
 import subprocess
 
+
 def check_for_executable(exe_name, args=['--version']):
     try:
         cmd = [exe_name]
@@ -13,6 +14,7 @@ def check_for_executable(exe_name, args=['--version']):
         return True
     except subprocess.CalledProcessError:
         return False
+
 
 def main():
     import argparse


### PR DESCRIPTION
Test whether the 'ninja' command is available, and fall back on the
CMake default (i.e. 'make') if 'ninja' is not present.

Ninja is beneficial as it reduces the build time by approximately a
factor 2. However, we shouldn't rely on its presence.