### PR TITLE
Run ffig module directly

### DIFF
--- a/cmake/ffig.cmake
+++ b/cmake/ffig.cmake
@@ -66,7 +66,7 @@ function(ffig_add_library)
   endif()
 
   add_custom_command(OUTPUT ${ffig_outputs}
-    COMMAND ${PYTHON_EXECUTABLE} ffig/FFIG.py ${ffig_invocation}
+    COMMAND ${PYTHON_EXECUTABLE} ffig ${ffig_invocation}
     DEPENDS ${input}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 

--- a/ffig/FFIG.py
+++ b/ffig/FFIG.py
@@ -134,7 +134,7 @@ def run(args):
     cwd = os.getcwd()
 
     # FIXME: Remove the need for this constraint.
-    if len(args.inputs) != 1:
+    if len(args.inputs) > 1:
         raise Exception("Multiple input files are currently not supported.")
 
     # FIXME: Loop over files and extend the model once we can handle multiple
@@ -166,7 +166,9 @@ def main():
         '-i', '--input',
         nargs='+',
         help='header files for input',
-        dest='inputs')
+        default=[],
+        dest='inputs',
+        required=True)
     parser.add_argument(
         '--libclang',
         help='path to libclang',
@@ -197,6 +199,3 @@ def main():
     args = parser.parse_args()
 
     run(args)
-
-if __name__ == '__main__':
-    main()

--- a/ffig/FFIG.py
+++ b/ffig/FFIG.py
@@ -130,7 +130,7 @@ def set_template_env(template_dir):
     return env
 
 
-def main(args):
+def run(args):
     cwd = os.getcwd()
 
     # FIXME: Remove the need for this constraint.
@@ -153,7 +153,8 @@ def main(args):
         env,
         args.output_dir)
 
-if __name__ == '__main__':
+
+def main():
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
@@ -195,4 +196,7 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    main(args)
+    run(args)
+
+if __name__ == '__main__':
+    main()

--- a/ffig/__main__.py
+++ b/ffig/__main__.py
@@ -1,0 +1,9 @@
+import sys
+import os
+
+from FFIG import main as ffig_main
+
+if sys.argv[0].endswith('__main__.py'):
+    sys.argv[0] = '%s -m ffig' % sys.executable
+
+ffig_main()


### PR DESCRIPTION
Changes to allow ffig module to be run as `python ffig`.

I can't get `python -m ffig` to work as it has issues with imports. Any input here would be great.