### PR TITLE
N253: Move annotations code out of cppmodel.

### DIFF
--- a/ffig/FFIG.py
+++ b/ffig/FFIG.py
@@ -46,7 +46,8 @@ def collect_api_and_obj_classes(classes, api_annotation):
     class APIClass:
 
         def __init__(self, model_class):
-            self.api_class = ffig.annotations.apply_class_annotations(model_class)
+            self.api_class = ffig.annotations.apply_class_annotations(
+                model_class)
             self.impls = []
 
     api_classes = {c.name: APIClass(c)

--- a/ffig/FFIG.py
+++ b/ffig/FFIG.py
@@ -16,6 +16,7 @@ import sys
 
 logging.basicConfig(level=logging.WARNING)
 
+import ffig.annotations
 import ffig.cppmodel
 import ffig.filters.capi_filter
 import ffig.generators
@@ -45,7 +46,7 @@ def collect_api_and_obj_classes(classes, api_annotation):
     class APIClass:
 
         def __init__(self, model_class):
-            self.api_class = ffig.cppmodel.apply_class_annotations(model_class)
+            self.api_class = ffig.annotations.apply_class_annotations(model_class)
             self.impls = []
 
     api_classes = {c.name: APIClass(c)
@@ -54,7 +55,7 @@ def collect_api_and_obj_classes(classes, api_annotation):
     for c in classes:
         for base in c.base_classes:
             if base in api_classes:
-                ffig.cppmodel.apply_class_annotations(c)
+                ffig.annotations.apply_class_annotations(c)
                 api_classes[base].impls.append(c)
 
     return [c for k, c in api_classes.items()]

--- a/ffig/annotations.py
+++ b/ffig/annotations.py
@@ -1,0 +1,34 @@
+from ffig.clang.cindex import CursorKind, TypeKind
+
+def _set_impl_name(o):
+    o.impl_name = o.name
+    names = [a for a in o.annotations if a.startswith("FFIG:NAME:")]
+    if names:
+        o.name = names[-1].replace("FFIG:NAME:", "")
+
+
+def apply_class_annotations(model_class):
+    _set_impl_name(model_class)
+
+    for m in model_class.methods:
+        _set_impl_name(m)
+
+        if "FFIG:PROPERTY" in m.annotations:
+            m.is_property = True
+        if m.is_pure_virtual:
+            model_class.is_abstract = True
+
+        if m.return_type.kind == TypeKind.VOID:
+            m.returns_void = True
+        elif m.return_type.kind in [TypeKind.INT, TypeKind.BOOL, TypeKind.DOUBLE]:
+            pass
+        elif m.return_type.kind == TypeKind.POINTER and m.return_type.pointee.kind == TypeKind.CHAR_S:
+            pass
+        elif m.return_type.kind == TypeKind.POINTER:
+            m.returns_sub_object = True
+            m.returns_nullable = True
+        elif m.return_type.kind == TypeKind.LVALUEREFERENCE:
+            m.returns_sub_object = True
+            m.returns_nullable = False
+
+    return model_class

--- a/ffig/annotations.py
+++ b/ffig/annotations.py
@@ -1,5 +1,6 @@
 from ffig.clang.cindex import CursorKind, TypeKind
 
+
 def _set_impl_name(o):
     o.impl_name = o.name
     names = [a for a in o.annotations if a.startswith("FFIG:NAME:")]

--- a/ffig/cppmodel.py
+++ b/ffig/cppmodel.py
@@ -193,4 +193,3 @@ class Model(object):
                 child_namespaces = list(namespaces)
                 child_namespaces.append(c.spelling)
                 self.add_child_nodes(c, child_namespaces)
-

--- a/ffig/cppmodel.py
+++ b/ffig/cppmodel.py
@@ -194,36 +194,3 @@ class Model(object):
                 child_namespaces.append(c.spelling)
                 self.add_child_nodes(c, child_namespaces)
 
-
-def _set_impl_name(o):
-    o.impl_name = o.name
-    names = [a for a in o.annotations if a.startswith("FFIG:NAME:")]
-    if names:
-        o.name = names[-1].replace("FFIG:NAME:", "")
-
-
-def apply_class_annotations(model_class):
-    _set_impl_name(model_class)
-
-    for m in model_class.methods:
-        _set_impl_name(m)
-
-        if "FFIG:PROPERTY" in m.annotations:
-            m.is_property = True
-        if m.is_pure_virtual:
-            model_class.is_abstract = True
-
-        if m.return_type.kind == TypeKind.VOID:
-            m.returns_void = True
-        elif m.return_type.kind in [TypeKind.INT, TypeKind.BOOL, TypeKind.DOUBLE]:
-            pass
-        elif m.return_type.kind == TypeKind.POINTER and m.return_type.pointee.kind == TypeKind.CHAR_S:
-            pass
-        elif m.return_type.kind == TypeKind.POINTER:
-            m.returns_sub_object = True
-            m.returns_nullable = True
-        elif m.return_type.kind == TypeKind.LVALUEREFERENCE:
-            m.returns_sub_object = True
-            m.returns_nullable = False
-
-    return model_class


### PR DESCRIPTION
The (ffig-specific) annotations code has been moved out of cppmodel.py
and into annotations.py. This makes cppmodel more general (and
reusable).

Closes #253.