### PR TITLE
N147: Derived classes in Go.

### DIFF
--- a/ffig/filters/capi_filter.py
+++ b/ffig/filters/capi_filter.py
@@ -43,7 +43,7 @@ def to_c(t, m):
     raise Exception('Type {} has no known c equivalent'.format(t.name))
 
 
-def to_go(t):
+def to_go(t, impl):
     if t.kind == TypeKind.INT:
         return 'int'
     if t.kind == TypeKind.DOUBLE:
@@ -52,7 +52,7 @@ def to_go(t):
         if t.pointee.kind == TypeKind.CHAR_S:
             return 'string'
         if t.pointee.kind == TypeKind.RECORD:
-            return t.pointee.name.replace('const ', '')
+            return impl
     raise Exception('Type {} has no known Go equivalent'.format(t.name))
 
 

--- a/ffig/templates/ffig.macros
+++ b/ffig/templates/ffig.macros
@@ -3,9 +3,8 @@
  #   Format a list of items separated by commas. Each item is formatted
  #   according to the callback body. Leading and trailing commas can be
  #   added by setting leading_comma or trailing_comma to True.
- #   An optional extra parameter can be passed, which is provided to the
- #   callback. If no extra parameter is passed, the callback is expected
- #   to have only one parameter.
+ #   Optional extra parameters can be passed at the end. These are
+ #   forwarded to the callback.
  #
  # Usage example: The example below generates Python code to join a list of
  #                items that are converted to strings. The text to output for
@@ -16,14 +15,10 @@
  #       {%- endcall -%}
  #   )
  #}
-{%- macro comma_separated_list(items, leading_comma=False, trailing_comma=False, extraParam=None) -%}
+{%- macro comma_separated_list(items, leading_comma=False, trailing_comma=False) -%}
     {%- for item in items -%}
         {%- if leading_comma and loop.first %}, {% endif -%}
-        {%- if extraParam -%}
-            {{ caller(item, extraParam) }}
-        {%- else -%}
-            {{ caller(item) }}
-        {%- endif -%}
+            {{ caller(item, *varargs) }}
         {%- if trailing_comma or not loop.last %}, {% endif -%}
     {%- endfor -%}
 {%- endmacro -%}

--- a/ffig/templates/ffig.macros
+++ b/ffig/templates/ffig.macros
@@ -3,6 +3,9 @@
  #   Format a list of items separated by commas. Each item is formatted
  #   according to the callback body. Leading and trailing commas can be
  #   added by setting leading_comma or trailing_comma to True.
+ #   An optional extra parameter can be passed, which is provided to the
+ #   callback. If no extra parameter is passed, the callback is expected
+ #   to have only one parameter.
  #
  # Usage example: The example below generates Python code to join a list of
  #                items that are converted to strings. The text to output for
@@ -13,10 +16,14 @@
  #       {%- endcall -%}
  #   )
  #}
-{%- macro comma_separated_list(items, leading_comma=False, trailing_comma=False) -%}
+{%- macro comma_separated_list(items, leading_comma=False, trailing_comma=False, extraParam=None) -%}
     {%- for item in items -%}
         {%- if leading_comma and loop.first %}, {% endif -%}
-        {{ caller(item) }}
+        {%- if extraParam -%}
+            {{ caller(item, extraParam) }}
+        {%- else -%}
+            {{ caller(item) }}
+        {%- endif -%}
         {%- if trailing_comma or not loop.last %}, {% endif -%}
     {%- endfor -%}
 {%- endmacro -%}

--- a/ffig/templates/go.macros
+++ b/ffig/templates/go.macros
@@ -26,9 +26,9 @@
  # go_method_parameters:
  #   List of parameter names and types converted to Go types.
  #}
-{%- macro go_method_parameters(method, leading_comma=False, trailing_comma=False) -%}
-    {%- call(arg) ffig_macros.comma_separated_list(method.arguments, leading_comma, trailing_comma) -%}
-        {{arg.name}} {{arg.type | to_go}}
+{%- macro go_method_parameters(method, impl, leading_comma=False, trailing_comma=False) -%}
+    {%- call(arg, impl) ffig_macros.comma_separated_list(method.arguments, leading_comma, trailing_comma, impl) -%}
+        {{arg.name}} {{arg.type | to_go(impl.name)}}
     {%- endcall -%}
 {%- endmacro -%}
 

--- a/ffig/templates/go.tmpl
+++ b/ffig/templates/go.tmpl
@@ -21,20 +21,21 @@ func init() {
 }
 
 {% for class in classes %}
-type {{class.name}} struct {
+{%- for impl in class.impls %}
+type {{impl.name}} struct {
     ptr C.{{module.name}}_{{class.name}}
 }
+{% endfor -%}
 {% endfor %}
 
 {% for class in classes -%}
 {% for impl in class.impls %}
 {% for method in impl.constructors %}
-
-func {{ impl.name }}_create({{go_macros.go_method_parameters(method)}}) ({{class.name}}, bool) {
+func {{ impl.name }}_create({{go_macros.go_method_parameters(method, impl)}}) ({{impl.name}}, bool) {
     var pv C.RT_{{module.name}}_{{impl.name}}_create
     pv = C.CGo_{{module.name}}_{{impl.name}}_create({{go_macros.go_arguments_to_c_arguments(module, method)}})
 
-    var obj {{class.name}}
+    var obj {{impl.name}}
 
     if pv.status == 0 {
         obj.ptr = pv.ptr
@@ -43,16 +44,16 @@ func {{ impl.name }}_create({{go_macros.go_method_parameters(method)}}) ({{class
         return obj, true
     }
 }
-
 {%- endfor %}
 {%- endfor %}
 {% endfor %}
 
 {% for class in classes -%}
+{% for impl in class.impls %}
 {% for method in class.methods %}
-func (obj {{class.name}}) {{method.name|to_go_method_name}}({{go_macros.go_method_parameters(method)}})
+func (obj {{impl.name}}) {{method.name|to_go_method_name}}({{go_macros.go_method_parameters(method, impl)}})
         {%- if not method.returns_void -%}
-            ({{method.return_type|to_go}}, bool)
+            ({{method.return_type|to_go(impl)}}, bool)
         {%- else -%}
             bool
         {%- endif -%} {
@@ -67,10 +68,11 @@ func (obj {{class.name}}) {{method.name|to_go_method_name}}({{go_macros.go_metho
         {% else %}return rv.status{% endif %}
     } else {
         {% if not method.returns_void %}
-        var value {{method.return_type|to_go}}
+        var value {{method.return_type|to_go(impl)}}
         return value, false
         {% else %}return rv.status{% endif %}
     }
 }
+{% endfor %}
 {% endfor %}
 {%- endfor %}


### PR DESCRIPTION
This commit causes the Go bindings to be generated with one type per
derived C++ class (and no type for the base class).

Each generated type has its own set of methods. Each generated type
stores a pointer to the underlying C++ object (which is held as a
pointer to base).

There's currently no support for anything polymorphic, since the base
class is not exposed directly in Go after this commit, and there's no
support for further descendants either.

This allows you to write things like

var c, Circle
c = Shape.Circle_create(...)

and opens up the possibility for smarter handling of objects by exposing
their real type directly to Go.

Closes #147.