### PR TITLE
Use xcode9.2 / macOS 10.12 images on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
 
     - os: osx
       language: generic
-      osx_image: xcode8
+      osx_image: xcode9.2
       install:
         - brew update
         - brew install ninja python3

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ matrix:
       install:
         - brew update
         - brew install ninja python3
-        - sudo pip2 install --upgrade pip && sudo pip2 install jinja2 nose pycodestyle
-        - sudo pip3 install --upgrade pip && sudo pip3 install jinja2 nose pycodestyle
+        - pip2 install --user --upgrade pip && pip2 install --user jinja2 nose pycodestyle
+        - pip3 install --user --upgrade pip && pip3 install --user jinja2 nose pycodestyle
         - gem install ffi
       script:
         - ./scripts/build.py -t


### PR DESCRIPTION
The dotnet core runtime requires at least 10.12 to run but the current
setting is xcode8 / macOS 10.11.