### PR TITLE
Regenerate bindings if any ffig source or templates have changed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,8 @@ if(Go_FOUND)
   list(APPEND all_ffig_bindings "GO")
 endif()
 
+file(GLOB_RECURSE FFIG_SOURCE ${CMAKE_SOURCE_DIR}/ffig/*)
+
 # Add FFIG build targets
 ffig_add_library(NAME Shape INPUTS tests/input/Shape.h ${all_ffig_bindings})
 ffig_add_library(NAME Tree INPUTS tests/input/Tree.h NOEXCEPT PYTHON CPP D SWIFT DOTNET)

--- a/cmake/ffig.cmake
+++ b/cmake/ffig.cmake
@@ -87,9 +87,8 @@ function(ffig_add_library)
 
   add_custom_command(OUTPUT ${ffig_outputs}
     COMMAND ${PYTHON_EXECUTABLE} -m ffig ${ffig_invocation}
-    DEPENDS ${input}
+    DEPENDS ${input} ${FFIG_SOURCE}
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-
 
   # FIXME: This is a bit ugly. The header is copied next to the generated bindings.
   file(COPY ${input} DESTINATION ${ffig_output_dir}/)


### PR DESCRIPTION
Expose a variable `FFIG_SOURCE` from cmake/ffig.cmake so that we can make FFIG build targets depend on the FFIG source and templates.

This adds correct dependencies and avoids having to remember to run `./scripts/build.py --clean` after templates have changed.