### PR TITLE
Modify dotnet templates to respect properties

### DIFF
--- a/ffig/templates/cs.tmpl
+++ b/ffig/templates/cs.tmpl
@@ -66,6 +66,7 @@ namespace {{module.name}}_c {
   {% for method in class.methods %}
 
     {% if not method.returns_void %}
+    {% if not method.is_property %}
     public {{method.return_type|to_dotnet_return_type}} {{method.name}}({{cs_macros.method_parameters(method)}}) {
       {{method.return_type|to_dotnet_output_value("rv")}};
       int rc = {{module.name}}_{{class.name}}_{{method.name}}(c_obj_, {{cs_macros.method_arguments(method, trailing_comma=True)}}out rv);
@@ -79,6 +80,23 @@ namespace {{module.name}}_c {
       {% endif %}
       return {{method.return_type|to_dotnet_return_value("rv")}};
     }
+    {% else %}
+    public {{method.return_type|to_dotnet_return_type}} {{method.name}} {
+      get {
+        {{method.return_type|to_dotnet_output_value("rv")}};
+        int rc = {{module.name}}_{{class.name}}_{{method.name}}(c_obj_, {{cs_macros.method_arguments(method, trailing_comma=True)}}out rv);
+        if(rc != 0) {
+          throw new {{module.name}}_c.Exception();
+        }
+        {% if method.returns_nullable %}
+        if(rv == IntPtr.Zero) {
+          return null;
+        }
+        {% endif %}
+        return {{method.return_type|to_dotnet_return_value("rv")}};
+      }
+    }
+    {% endif %}
     {% else %}
     public void {{method.name}}({{cs_macros.method_parameters(method)}}) {
       int rc = {{module.name}}_{{class.name}}_{{method.name}}(c_obj_, {{cs_macros.method_arguments(method)}});

--- a/tests/dotnet/TestShape.cs.in
+++ b/tests/dotnet/TestShape.cs.in
@@ -12,7 +12,7 @@ namespace TestFFIG
           double radius = 2.0;
           var circle = new Circle(radius);
           
-          Assert.AreEqual(circle.name(), "Circle");
+          Assert.AreEqual(circle.name, "Circle");
         }
         
         [TestMethod]
@@ -21,7 +21,7 @@ namespace TestFFIG
           double radius = 2.0;
           var circle = new Circle(radius);
           
-          Assert.AreEqual(circle.area(), 12.56637061436, 10);
+          Assert.AreEqual(circle.area, 12.56637061436, 10);
         }
         
         [TestMethod]
@@ -30,7 +30,7 @@ namespace TestFFIG
           double radius = 2.0;
           var circle = new Circle(radius);
           
-          Assert.AreEqual(circle.perimeter(), 12.5663706144, 10);
+          Assert.AreEqual(circle.perimeter, 12.5663706144, 10);
         }
         
         [TestMethod]

--- a/tests/expected_output/Shape.cs.expected
+++ b/tests/expected_output/Shape.cs.expected
@@ -48,31 +48,37 @@ namespace Shape_c {
       Shape_AbstractShape_dispose(c_obj_);
     }
 
-    public double area() {
-      double rv;
-      int rc = Shape_AbstractShape_area(c_obj_, out rv);
-      if(rc != 0) {
-        throw new Shape_c.Exception();
+    public double area {
+      get {
+        double rv;
+        int rc = Shape_AbstractShape_area(c_obj_, out rv);
+        if(rc != 0) {
+          throw new Shape_c.Exception();
+        }
+        return rv;
       }
-      return rv;
     }
 
-    public double perimeter() {
-      double rv;
-      int rc = Shape_AbstractShape_perimeter(c_obj_, out rv);
-      if(rc != 0) {
-        throw new Shape_c.Exception();
+    public double perimeter {
+      get {
+        double rv;
+        int rc = Shape_AbstractShape_perimeter(c_obj_, out rv);
+        if(rc != 0) {
+          throw new Shape_c.Exception();
+        }
+        return rv;
       }
-      return rv;
     }
 
-    public string name() {
-      IntPtr rv = IntPtr.Zero;
-      int rc = Shape_AbstractShape_name(c_obj_, out rv);
-      if(rc != 0) {
-        throw new Shape_c.Exception();
+    public string name {
+      get {
+        IntPtr rv = IntPtr.Zero;
+        int rc = Shape_AbstractShape_name(c_obj_, out rv);
+        if(rc != 0) {
+          throw new Shape_c.Exception();
+        }
+        return Marshal.PtrToStringAnsi(rv);
       }
-      return Marshal.PtrToStringAnsi(rv);
     }
 
     public int is_equal(AbstractShape s) {


### PR DESCRIPTION
When a method is annotated as a property, CS code will be generated as follows:

```
public type name {
  get {
    // C-API call code
  }
}
```