### PR TITLE
Use checked casts to and from CAPI types

### DIFF
--- a/ffig/filters/capi_filter.py
+++ b/ffig/filters/capi_filter.py
@@ -21,7 +21,7 @@ def restore_cpp_type(a):
         if t.pointee.kind == TypeKind.RECORD:
             # This is a hack until we can get an unqualified type from libclang
             type_name = t.pointee.name.replace('const ', '')
-            return '&(**static_cast<{}_ptr>({}))'.format(type_name, n)
+            return '&(**capi_to_cpp_cast<{}>({}))'.format(type_name, n)
     raise Exception(
         'Type {} has no defined C++ type restoration (adding one for primitives is trivial)'.format(t.name))
 

--- a/ffig/templates/_c.cpp.tmpl
+++ b/ffig/templates/_c.cpp.tmpl
@@ -21,14 +21,41 @@ const char* {{module.name}}_error()
 
 namespace {
 {% for class in classes %}
-  using {{class.name}}_ptr = const std::shared_ptr<{{class.impl_name}}>*;
+  using {{class.name}}_ptr = std::shared_ptr<{{class.impl_name}}>*;
 {% endfor %}
+
+// C-API types are pointers to undefined structs so that a C compiler can warn 
+// if they are used in the wrong places 
+// (CAPIShape_t* and CAPITree_t* are not the same type).
+// Wrappers around reinterpret_cast allow casts to and from C-API types to be checked.
+
+template <class CppType> struct capi_type_t;
+{% for class in classes %}
+template<> struct capi_type_t<{{class.impl_name}}> { using type = {{module.name}}_{{class.name}}; };
+{% endfor %}
+template <class T>
+using capi_type = typename capi_type_t<T>::type;
+
+template<class CppType>
+auto capi_to_cpp_cast(capi_type<CppType> o) { 
+  return reinterpret_cast<std::shared_ptr<CppType>*>(o);
+}
+
+template<class CppType>
+void* capi_to_cpp_cast(...) = delete;
+
+template<class CppType>
+auto cpp_to_capi_cast(std::shared_ptr<CppType>* p) { 
+  return reinterpret_cast<capi_type<CppType>>(p);
+}
+void* cpp_to_capi_cast(...) = delete;
+
 } // end anonymous namespace
 
 {% for class in classes %}
 void {{module.name}}_{{ class.name }}_dispose({{module.name}}_{{class.name}} my{{class.name}})
 {
-  delete static_cast<{{class.name}}_ptr>(my{{class.name}});
+  delete capi_to_cpp_cast<{{class.impl_name}}>(my{{class.name}});
 }
 {% if not class.is_abstract %}
 {% for method in class.constructors %}
@@ -39,8 +66,9 @@ int {{module.name}}_{{class.name}}_create(
 {
     try
     {
-        auto p = std::make_unique<const {{class.impl_name}}>({{c_macros.method_arguments(method)}});
-        *rv = new std::shared_ptr<const {{class.impl_name}}>(p.release());
+        auto p = std::make_unique<{{class.impl_name}}>({{c_macros.method_arguments(method)}});
+        auto new_obj = new std::shared_ptr<{{class.impl_name}}>(p.release());
+        *rv = cpp_to_capi_cast(new_obj);
     }
     catch (const std::exception& e)
     {
@@ -54,8 +82,9 @@ int {{module.name}}_{{class.name}}_create(
 {{module.name}}_{{class.name}} {{module.name}}_{{ class.name }}_create_noexcept(
     {{c_macros.method_parameters(module, method)}}) 
 {
-    auto p = std::make_unique<const {{class.impl_name}}>({{c_macros.method_arguments(method)}});
-    return new std::shared_ptr<const {{class.impl_name}}>(p.release());
+    auto p = std::make_unique<{{class.impl_name}}>({{c_macros.method_arguments(method)}});
+    auto new_obj = new std::shared_ptr<{{class.impl_name}}>(p.release());
+    return cpp_to_capi_cast(new_obj);
 }
 {% endif %}
 {% endfor %}
@@ -75,13 +104,13 @@ int {{module.name}}_{{class.name}}_{{method.name}}(
     try
     {
         {% if method.returns_void %}
-        (*static_cast<{{class.name}}_ptr>(my{{class.name}}))->{{method.impl_name}}(
+        (*capi_to_cpp_cast<{{class.impl_name}}>(my{{class.name}}))->{{method.impl_name}}(
             {{c_macros.method_arguments(method)}});
         {% elif not method.returns_sub_object %}
-        *rv = (*static_cast<{{class.name}}_ptr>(my{{class.name}}))->{{method.impl_name}}(
+        *rv = (*capi_to_cpp_cast<{{class.impl_name}}>(my{{class.name}}))->{{method.impl_name}}(
             {{c_macros.method_arguments(method)}});
         {% else %}
-        auto p = static_cast<const {{class.name}}_ptr>(my{{class.name}});
+        auto p = capi_to_cpp_cast<{{class.impl_name}}>(my{{class.name}});
         auto subobj = (*p)->{{method.impl_name}}(
             {{c_macros.method_arguments(method)}});
         {% if method.returns_nullable %}
@@ -91,7 +120,8 @@ int {{module.name}}_{{class.name}}_{{method.name}}(
             return {{module.name}}_RC_SUCCESS;
         }
         {% endif %}
-        *rv = new std::shared_ptr<{{method.return_type.pointee}}>(*p, subobj);
+        auto new_obj = new std::shared_ptr<std::remove_reference_t<decltype(*subobj)>>(*p, subobj);
+        *rv = cpp_to_capi_cast(new_obj);
         {% endif %}
     }
     catch (const std::exception& e)
@@ -107,13 +137,13 @@ EXPORT {{method.return_type | to_c(module.name)}} {{module.name}}_{{ class.name 
     {{module.name}}_{{class.name}} my{{class.name}} {{c_macros.method_parameters(module, method, leading_comma=True)}})
 {
     {% if method.returns_void %}
-    (*static_cast<{{class.name}}_ptr>(my{{class.name}}))->{{method.impl_name}}(
+    (*capi_to_cpp_cast<{{class.impl_name}}>(my{{class.name}}))->{{method.impl_name}}(
         {{c_macros.method_arguments(method)}});
     {% elif not method.returns_sub_object %}
-    return (*static_cast<{{class.name}}_ptr>(my{{class.name}}))->{{method.impl_name}}(
+    return (*capi_to_cpp_cast<{{class.impl_name}}>(my{{class.name}}))->{{method.impl_name}}(
         {{c_macros.method_arguments(method)}});
     {% else %}
-    auto p = static_cast<const {{class.name}}_ptr>(my{{class.name}});
+    auto p = capi_to_cpp_cast<{{class.impl_name}}>(my{{class.name}});
     auto subobj = (*p)->{{method.impl_name}}(
         {{c_macros.method_arguments(method)}});
     {% if method.returns_nullable %}
@@ -122,7 +152,8 @@ EXPORT {{method.return_type | to_c(module.name)}} {{module.name}}_{{ class.name 
         return nullptr;
     }
     {% endif %}
-    return new std::shared_ptr<{{method.return_type.pointee}}>(*p, subobj);
+    auto new_obj = new std::shared_ptr<std::remove_reference_t<decltype(*subobj)>>(*p, subobj);
+    return cpp_to_capi_cast(new_obj);
     {% endif %}
 }
 {% endif %}
@@ -136,8 +167,9 @@ int {{module.name}}_{{impl.name}}_create(
 {
     try
     {
-        auto p = std::make_unique<const {{impl.impl_name}}>({{c_macros.method_arguments(method)}});
-        *rv = new std::shared_ptr<const {{class.impl_name}}>(p.release());
+        auto p = std::make_unique<{{impl.impl_name}}>({{c_macros.method_arguments(method)}});
+        auto new_obj = new std::shared_ptr<{{class.impl_name}}>(p.release());
+        *rv = cpp_to_capi_cast(new_obj);
     }
     catch (const std::exception& e)
     {
@@ -151,8 +183,9 @@ int {{module.name}}_{{impl.name}}_create(
 {{module.name}}_{{class.name}} {{module.name}}_{{impl.name}}_create_noexcept(
     {{c_macros.method_parameters(module, method)}}) 
 {
-    auto p = std::make_unique<const {{impl.impl_name}}>({{c_macros.method_arguments(method)}});
-    return new std::shared_ptr<const {{class.impl_name}}>(p.release());
+    auto p = std::make_unique<{{impl.impl_name}}>({{c_macros.method_arguments(method)}});
+    auto new_obj = (new std::shared_ptr<{{class.impl_name}}>(p.release()));
+    return cpp_to_capi_cast(new_obj);
 }
 {% endif %}
 {% endfor %}

--- a/ffig/templates/_c.h.tmpl
+++ b/ffig/templates/_c.h.tmpl
@@ -18,7 +18,8 @@
 #define EXPORT extern "C" __attribute__((visibility("default")))
 #endif
 {% for class in classes %}
-typedef const void* {{module.name}}_{{class.name}};
+struct {{module.name}}_{{class.name}}_t;
+typedef struct {{module.name}}_{{class.name}}_t* {{module.name}}_{{class.name}};
 {% endfor %}
 #ifdef __cplusplus
 extern "C"

--- a/tests/input/Tree.h
+++ b/tests/input/Tree.h
@@ -22,12 +22,12 @@ class FFIG_EXPORT Tree
     right_ = std::make_shared<Tree>(levels-1);
   }
 
-  const Tree* left_subtree() const
+  Tree* left_subtree() const
   {
     return left_.get();
   }
 
-  const Tree* right_subtree() const
+  Tree* right_subtree() const
   {
     return right_.get();
   }


### PR DESCRIPTION
Fix for a loss-of-const bug in Tree bindings (identified by the checked casts).

closes #202