### PR TITLE
Move the CI status to the top of the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Continuous integration
+
+**Build status (on Travis-CI):** [![Build Status](https://travis-ci.org/FFIG/ffig.svg?branch=master)](https://travis-ci.org/FFIG/ffig)
+
+**Build status (on AppVeyor):** [![Build Status](https://ci.appveyor.com/api/projects/status/github/ffig/ffig?branch=master)](https://ci.appveyor.com/project/jbcoe/ffig?branch=master)
+
 # Description
 
 FFIG is a Foreign Function Interface Generator.
@@ -71,13 +77,6 @@ The build uses cmake driven by a simple Python script. To build and run tests, r
 ```
 ./scripts/build.py -t [--python-path=$(which python3)]
 ```
-
-# Continuous integration
-
-**Build status (on Travis-CI):** [![Build Status](https://travis-ci.org/FFIG/ffig.svg?branch=master)](https://travis-ci.org/FFIG/ffig)
-
-**Build status (on AppVeyor):** [![Build Status](https://ci.appveyor.com/api/projects/status/github/ffig/ffig?branch=master)](https://ci.appveyor.com/project/jbcoe/ffig?branch=master)
-
 
 # Issues
 


### PR DESCRIPTION
The CI status should be visible as early as possible in the README.