### PR TITLE
Tidy up the top of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
-# Continuous integration
-
 **Build status (on Travis-CI):** [![Build Status](https://travis-ci.org/FFIG/ffig.svg?branch=master)](https://travis-ci.org/FFIG/ffig)
 
 **Build status (on AppVeyor):** [![Build Status](https://ci.appveyor.com/api/projects/status/github/ffig/ffig?branch=master)](https://ci.appveyor.com/project/jbcoe/ffig?branch=master)
 
-# Description
-
-FFIG is a Foreign Function Interface Generator.
+# FFIG - a Foreign Function Interface Generator.
 
 This project uses libclang to read existing C++ class definitions and create
 equivalent classes in other languages (primarily Python for now) and binds them


### PR DESCRIPTION
This change removes the `Continuous Integration` heading, which was distracting from the more important description of ffig below. It also changes the title of the main section from `Description` to `FFIG - a Foreign Function Interface Generator`; which adds some weight to the top of the document and immediately introduces some useful information.