### PR TITLE
Add noexcept support for Python 2

### DIFF
--- a/ffig/templates/py2.tmpl
+++ b/ffig/templates/py2.tmpl
@@ -45,6 +45,16 @@ class {{class.name}}:
     @property
     {% endif %}
     def {{method.name}}(self{{py2_macros.method_parameters(method, leading_comma=True)}}):
+  {% if method.is_noexcept %}
+    {% if method.returns_void %}
+        conf.lib.{{module.name}}_{{class.name}}_{{method.name}}_noexcept(self{{py2_macros.method_arguments(method, leading_comma=True)}})
+    {% elif method.returns_sub_object or method.returns_object_by_value %}
+        rv = conf.lib.{{module.name}}_{{class.name}}_{{method.name}}_noexcept(self{{py2_macros.method_arguments(method, leading_comma=True)}})
+        return {{method.return_type|to_py2_ctype}}.from_capi(rv)
+    {% else %}
+        return conf.lib.{{module.name}}_{{class.name}}_{{method.name}}_noexcept(self{{py2_macros.method_arguments(method, leading_comma=True)}})
+    {% endif %} 
+  {%- else -%}
     {% if method.returns_void %}
         rc = conf.lib.{{module.name}}_{{class.name}}_{{method.name}}(self{{py2_macros.method_arguments(method, leading_comma=True)}})
         if rc != 0:
@@ -61,7 +71,8 @@ class {{class.name}}:
         if rc == 0:
             return rv.value
         raise {{module.name}}_error()
-    {% endif %}
+    {% endif -%} 
+  {%- endif -%}
 {% endfor %}
 
     @classmethod
@@ -82,7 +93,7 @@ class {{impl.name}}({{class.name}}):
         if not bool(ptr):
             return None
         return cls(_p=ptr)
-    {% for method in impl.constructors %}
+{% for method in impl.constructors %}
 
     def __init__(self, {{py2_macros.constructor_parameters(method, trailing_comma=True)}}_p=None):
         if _p:
@@ -123,9 +134,15 @@ methodList = [
 {% endfor %}
 {% endfor %}
 {% for method in class.methods %}
+    {% if method.is_noexcept %}
+    ("{{module.name}}_{{ class.name }}_{{method.name}}_noexcept",
+        [{{class.name}}{{py2_macros.method_argument_types(method, leading_comma=True)}}{% if not method.returns_void %}{% endif %}],
+        {{method.return_type|to_output_py2_ctype}}),
+    {% else %}
     ("{{module.name}}_{{ class.name }}_{{method.name}}",
         [{{class.name}}{{py2_macros.method_argument_types(method, leading_comma=True)}}{% if not method.returns_void %}, POINTER({{method.return_type|to_output_py2_ctype}}){% endif %}],
         c_int),
+    {% endif %}
 {% endfor %}
 {% endfor %}
 ]


### PR DESCRIPTION
Identical approach taken as that for Python 3 template.

Drive-by format fixes to Python 2 template made as diff between py3.tmpl and py2.tmpl was open.

closes #256