### PR TITLE
N260: noexcept support for C++ mock templates

### DIFF
--- a/ffig/annotations.py
+++ b/ffig/annotations.py
@@ -24,7 +24,7 @@ def apply_class_annotations(model_class):
         elif m.return_type.kind in [TypeKind.INT, TypeKind.BOOL, TypeKind.DOUBLE]:
             pass
         elif m.return_type.kind == TypeKind.POINTER and m.return_type.pointee.kind == TypeKind.CHAR_S:
-            pass
+            m.returns_chars = True
         elif m.return_type.kind == TypeKind.POINTER:
             m.returns_sub_object = True
             m.returns_nullable = True

--- a/ffig/templates/_mocks.h.tmpl
+++ b/ffig/templates/_mocks.h.tmpl
@@ -74,7 +74,11 @@ struct Mock{{class.name}} : {{class.name}}
 {%endfor%}
 
 {% for method in class.methods %}
+  {% if method.is_noexcept %}
+  {{method.return_type}} {{method.name}}({{method_parameters(method)}}) const noexcept override
+  {% else %}
   {{method.return_type}} {{method.name}}({{method_parameters(method)}}) const override
+  {% endif %}
   {
     return MockMethodResult()("{{method.name}}", {{method.name}}_
             {{method_arguments(method, leading_comma=True)}});

--- a/ffig/templates/cs.tmpl
+++ b/ffig/templates/cs.tmpl
@@ -81,7 +81,6 @@ namespace {{module.name}}_c {
     {% elif method.is_property %}
     public {{method.return_type|to_dotnet_return_type}} {{method.name}} {
       get {
-        {{method.return_type|to_dotnet_output_value("rv")}};
         var rv = {{module.name}}_{{class.name}}_{{method.name}}_noexcept(c_obj_{{cs_macros.method_arguments(method, leading_comma=True)}});
         {% if method.returns_nullable %}
         if(rv == IntPtr.Zero) {

--- a/ffig/templates/py3.tmpl
+++ b/ffig/templates/py3.tmpl
@@ -168,7 +168,9 @@ methodList = [
     {% if method.is_noexcept %}
     ("{{module.name}}_{{ class.name }}_{{method.name}}_noexcept",
         [{{class.name}}{{py3_macros.method_argument_types(method, leading_comma=True)}}{% if not method.returns_void %}{% endif %}],
-        {{method.return_type|to_output_py3_ctype}}),
+        {{method.return_type|to_output_py3_ctype}}{% if method.returns_chars %},
+        c_interop_string.to_python_string{% endif -%}
+        ),
     {% else %}
     ("{{module.name}}_{{ class.name }}_{{method.name}}",
         [{{class.name}}{{py3_macros.method_argument_types(method, leading_comma=True)}}{% if not method.returns_void %}, POINTER({{method.return_type|to_output_py3_ctype}}){% endif %}],

--- a/tests/expected_output/Shape.cs.expected
+++ b/tests/expected_output/Shape.cs.expected
@@ -23,13 +23,13 @@ namespace Shape_c {
     [DllImport("Shape_c")]
     private static extern int Shape_AbstractShape_dispose(IntPtr c_obj);
     [DllImport("Shape_c")]
-    private static extern int Shape_AbstractShape_area(IntPtr c_obj, out double rv);
+    private static extern double Shape_AbstractShape_area_noexcept(IntPtr c_obj);
     [DllImport("Shape_c")]
-    private static extern int Shape_AbstractShape_perimeter(IntPtr c_obj, out double rv);
+    private static extern double Shape_AbstractShape_perimeter_noexcept(IntPtr c_obj);
     [DllImport("Shape_c")]
-    private static extern int Shape_AbstractShape_name(IntPtr c_obj, out IntPtr rv);
+    private static extern IntPtr Shape_AbstractShape_name_noexcept(IntPtr c_obj);
     [DllImport("Shape_c")]
-    private static extern int Shape_AbstractShape_is_equal(IntPtr c_obj, IntPtr s, out int rv);
+    private static extern int Shape_AbstractShape_is_equal_noexcept(IntPtr c_obj, IntPtr s);
 
     protected IntPtr c_obj_;
 
@@ -45,40 +45,24 @@ namespace Shape_c {
     }
     public double area {
       get {
-        double rv;
-        int rc = Shape_AbstractShape_area(c_obj_, out rv);
-        if(rc != 0) {
-          throw new Shape_c.Exception();
-        }
+        var rv = Shape_AbstractShape_area_noexcept(c_obj_);
         return rv;
       }
     }
     public double perimeter {
       get {
-        double rv;
-        int rc = Shape_AbstractShape_perimeter(c_obj_, out rv);
-        if(rc != 0) {
-          throw new Shape_c.Exception();
-        }
+        var rv = Shape_AbstractShape_perimeter_noexcept(c_obj_);
         return rv;
       }
     }
     public string name {
       get {
-        IntPtr rv = IntPtr.Zero;
-        int rc = Shape_AbstractShape_name(c_obj_, out rv);
-        if(rc != 0) {
-          throw new Shape_c.Exception();
-        }
+        var rv = Shape_AbstractShape_name_noexcept(c_obj_);
         return Marshal.PtrToStringAnsi(rv);
       }
     }
     public int is_equal(AbstractShape s) {
-      int rv;
-      int rc = Shape_AbstractShape_is_equal(c_obj_, s.c_obj_, out rv);
-      if(rc != 0) {
-        throw new Shape_c.Exception();
-      }
+      var rv = Shape_AbstractShape_is_equal_noexcept(c_obj_, s.c_obj_);
       return rv;
     }
   }

--- a/tests/input/Shape.h
+++ b/tests/input/Shape.h
@@ -8,10 +8,10 @@ struct FFIG_EXPORT AbstractShape
   virtual ~AbstractShape()
   {
   }
-  virtual FFIG_PROPERTY double area() const = 0;
-  virtual FFIG_PROPERTY double perimeter() const = 0;
-  virtual FFIG_PROPERTY const char* name() const = 0;
-  virtual int is_equal(const AbstractShape* s) const = 0;
+  virtual FFIG_PROPERTY double area() const noexcept = 0;
+  virtual FFIG_PROPERTY double perimeter() const noexcept = 0;
+  virtual FFIG_PROPERTY const char* name() const noexcept = 0;
+  virtual int is_equal(const AbstractShape* s) const noexcept = 0;
 };
 
 static const double pi = 3.14159265359;
@@ -21,22 +21,22 @@ class Circle : public AbstractShape
   const double radius_;
 
 public:
-  double area() const override
+  double area() const noexcept override
   {
     return pi * radius_ * radius_;
   }
 
-  double perimeter() const override
+  double perimeter() const noexcept override
   {
     return 2 * pi * radius_;
   }
 
-  const char* name() const override
+  const char* name() const noexcept override
   {
     return "Circle";
   }
 
-  int is_equal(const AbstractShape* s) const override
+  int is_equal(const AbstractShape* s) const noexcept override
   {
     if ( auto c = dynamic_cast<const Circle*>(s) )
       return c->radius_ == radius_;
@@ -58,22 +58,22 @@ class Square : public AbstractShape
   const double side_;
 
 public:
-  double area() const override
+  double area() const noexcept override
   {
     return side_ * side_;
   }
 
-  double perimeter() const override
+  double perimeter() const noexcept override
   {
     return 4.0 * side_;
   }
 
-  const char* name() const override
+  const char* name() const noexcept override
   {
     return "Square";
   }
 
-  int is_equal(const AbstractShape* s) const override
+  int is_equal(const AbstractShape* s) const noexcept override
   {
     if ( auto sq = dynamic_cast<const Square*>(s) )
       return sq->side_ == side_;
@@ -95,22 +95,22 @@ class Pentagon : public AbstractShape
   const double side_;
 
 public:
-  double area() const override
+  double area() const noexcept override
   {
     return 0.25 * sqrt(5. * (5. + 2. * sqrt(5.))) * side_ * side_;
   }
 
-  double perimeter() const override
+  double perimeter() const noexcept override
   {
     return 5.0 * side_;
   }
 
-  const char* name() const override
+  const char* name() const noexcept override
   {
     return "Pentagon";
   }
 
-  int is_equal(const AbstractShape* s) const override
+  int is_equal(const AbstractShape* s) const noexcept override
   {
     if ( auto p = dynamic_cast<const Pentagon*>(s) )
       return p->side_ == side_;

--- a/tests/src/TestShapeMocks.cpp
+++ b/tests/src/TestShapeMocks.cpp
@@ -10,26 +10,6 @@ TEST_CASE("MockAbstractShape", "[mocks::MockAbstractShape]")
 {
   static_assert(std::is_base_of<AbstractShape,mocks::MockAbstractShape>::value,"");
 
-  GIVEN("A mock shape with no expected values set")
-  {
-    mocks::MockAbstractShape shape;
-
-    THEN("All method invocations lead to exceptions")
-    {
-      REQUIRE_THROWS_AS(shape.name(),
-                        mocks::MockAbstractShape::MockMethodResultNotSpecified);
-
-      REQUIRE_THROWS_AS(shape.area(),
-                        mocks::MockAbstractShape::MockMethodResultNotSpecified);
-
-      REQUIRE_THROWS_AS(shape.perimeter(),
-                        mocks::MockAbstractShape::MockMethodResultNotSpecified);
-
-      //REQUIRE_THROWS_AS(shape.is_equal(&shape),
-      //                  mocks::MockAbstractShape::MockMethodResultNotSpecified);
-    }
-  }
-
   GIVEN("A mock shape with expected values set")
   {
     mocks::MockAbstractShape shape;


### PR DESCRIPTION
## What does this PR do? 
This pull request adds support for `noexcept` member functions to the C++ mocks template. It also tags the member functions of the `Shape` class hierarchy as `noexcept`, allowing us to test that the mock classes are generated with appropriate `noexcept` specs.

I had to remove a test that throws when no expected value is set for the mock object, as this would violate the `noexcept` specification and cause the test to terminate.

## Closes [github issues]
Closes #260.

## Where should the reviewer start?
Begin by determining whether we are happy with the removal of the test for the unset mock objects. From there, inspect the template and `Shape.h` to verify correct implementation.

## Ideas that were considered and discarded
It occurred to me that we could return some proxy object that has implicit conversion to the correct return type, which would throw if the expected value was not set. I didn't explore this route as it would add (likely) unnecessary complexity.

## Possible future work
Reinstate the throw-if-no-expected-value-set test with another class / class hierarchy. Shape is used widely and is a good candidate for `noexcept` testing. Perhaps the `Animal` classes could be used to test the unset-value mock behaviour?