### PR TITLE
N397: Support building `cppmodel` objects from source strings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,13 @@ set_property(TEST test_cppmodel
   PROPERTY LABELS INFRASTRUCTURE)
 
 add_test(
+  NAME test_ffig
+  COMMAND ${PYTHON_EXECUTABLE} -m nose -v ${CMAKE_CURRENT_LIST_DIR}/tests/ffig
+  WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/ffig)
+set_property(TEST test_ffig
+  PROPERTY LABELS INFRASTRUCTURE)
+
+add_test(
   NAME test_python_bindings
   COMMAND ${PYTHON_EXECUTABLE} -m nose -v ${CMAKE_CURRENT_LIST_DIR}/tests
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/generated)

--- a/ffig/FFIG.py
+++ b/ffig/FFIG.py
@@ -86,11 +86,14 @@ def write_bindings_to_disk(
 
 def build_model_from_source(
         path_to_source,
-        module_name):
+        module_name,
+        unsaved_files=None):
     """
     Input:
     - full path to source file
     - module_name taken from args
+    - [Optional] List of 2-tuples of unsaved file content in the format:
+      (filename, content_string)
 
     Returns:
     - model built from a clang.cindex TranslationUnit with a name from args
@@ -98,7 +101,8 @@ def build_model_from_source(
     ffig_include_dir = os.path.join(os.path.dirname(__file__), 'include')
     tu = clang.cindex.TranslationUnit.from_source(
         path_to_source,
-        '-x c++ -std=c++14 -stdlib=libc++ -I{}'.format(ffig_include_dir).split())
+        '-x c++ -std=c++14 -stdlib=libc++ -I{}'.format(ffig_include_dir).split(),
+        unsaved_files=unsaved_files)
 
     model = ffig.cppmodel.Model(tu)
     model.module_name = module_name

--- a/tests/ffig/test_build_model.py
+++ b/tests/ffig/test_build_model.py
@@ -1,0 +1,13 @@
+import ffig.FFIG
+from nose.tools import assert_equals
+
+
+def test_build_model_from_str():
+    source = 'class A{}; void foo();'
+    filename = 'test.cpp'
+    model = ffig.FFIG.build_model_from_source(filename, 'test_source',
+            [(filename, source)])
+
+    assert_equals(
+            str(model),
+            "<cppmodel.Model filename=test.cpp, classes=['A'], functions=['foo']>")


### PR DESCRIPTION
## What does this PR do? 
As well as building a `cppmodel` from a file, we should be able to build
it from a string containing source code.

This facilitates the ffig-explorer use case, as well as other future
uses.

## Closes #397.