### PR TITLE
N399: Remove unused `TypeKind` import.

### DIFF
--- a/tests/cppmodel/test_model.py
+++ b/tests/cppmodel/test_model.py
@@ -1,6 +1,5 @@
 from util import get_tu
 import ffig.cppmodel
-from ffig.clang.cindex import TypeKind
 from nose.tools import assert_equals
 
 


### PR DESCRIPTION
## What does this PR do? 
Remove unused `TypeKind` import from `tests/cppmodel/test_model.py`.

## Closes #399.