### PR TITLE
N402: Add descriptions to binding generators.

### DIFF
--- a/ffig/generators/generator_aliases.py
+++ b/ffig/generators/generator_aliases.py
@@ -4,15 +4,15 @@
 import ffig.generators
 
 aliases = {
-    'dotnet': 'cs.tmpl',
-    'lua': 'lua.tmpl',
-    'ruby': 'rb.tmpl',
+    'dotnet': ('cs.tmpl', 'dotnet (C#) bindings'),
+    'lua': ('lua.tmpl', 'Lua bindings'),
+    'ruby': ('rb.tmpl', 'Ruby bindings'),
 }
 
 
 def aliased_generator(module_name, binding, api_classes, env, output_dir):
     try:
-        binding = aliases[binding]
+        binding = aliases[binding][0]
     except KeyError:
         raise Exception('No alias for {0}'.format(binding))
 
@@ -21,4 +21,5 @@ def aliased_generator(module_name, binding, api_classes, env, output_dir):
 
 
 def setup_plugin(context):
-    context.register(aliased_generator, aliases.keys())
+    bindings = [(key, value[1]) for key, value in aliases.items()]
+    context.register(aliased_generator, bindings)

--- a/ffig/generators/go.py
+++ b/ffig/generators/go.py
@@ -56,4 +56,4 @@ def go_generator(module_name, binding, api_classes, env, output_dir):
 
 
 def setup_plugin(context):
-    context.register(go_generator, ['go'])
+    context.register(go_generator, [('go', 'Go bindings using CGo')])

--- a/ffig/generators/python.py
+++ b/ffig/generators/python.py
@@ -30,4 +30,8 @@ def generator(module_name, binding, api_classes, env, output_dir):
 
 
 def setup_plugin(context):
-    context.register(generator, ['python'])
+    context.register(
+            generator,
+            [
+                ('python', 'Python2 and Python3 generator using ctypes')
+            ])

--- a/tests/ffig/test_generator_list.py
+++ b/tests/ffig/test_generator_list.py
@@ -1,0 +1,8 @@
+import ffig.generators
+from nose.tools import assert_equals
+
+def test_generator_list():
+    python_entry = filter(lambda x: x[0] == 'python',
+           ffig.generators.generator_context.list_generators())[0]
+
+    assert_equals(python_entry[1], 'Python2 and Python3 generator using ctypes')

--- a/tests/ffig/test_generator_list.py
+++ b/tests/ffig/test_generator_list.py
@@ -2,7 +2,7 @@ import ffig.generators
 from nose.tools import assert_equals
 
 def test_generator_list():
-    python_entry = filter(lambda x: x[0] == 'python',
-           ffig.generators.generator_context.list_generators())[0]
+    python_entry = list(filter(lambda x: x[0] == 'python',
+        ffig.generators.generator_context.list_generators()))[0]
 
     assert_equals(python_entry[1], 'Python2 and Python3 generator using ctypes')


### PR DESCRIPTION
## What does this PR do?

Generators now include a description for each binding they register.

These can be used to add a `--list-generators` feature.

This commit contains work for issue #402 but does not complete the work for this issue.