### PR TITLE
Use nunit for dotnet tests so that we can support mono easily

### DIFF
--- a/tests/dotnet/TestNumber.cs
+++ b/tests/dotnet/TestNumber.cs
@@ -1,12 +1,12 @@
 using Number_c;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NUnit.Framework;
 
 namespace TestFFIG
 {
-    [TestClass]
+    [TestFixture]
     public class TestNumber
     {
-        [TestMethod]
+        [Test]
         public void NumberValue()
         {
           var number = new Number(8);
@@ -14,7 +14,7 @@ namespace TestFFIG
           Assert.AreEqual(number.value(), 8);
         }
         
-        [TestMethod]
+        [Test]
         public void NumberNext()
         {
           var number = new Number(8);

--- a/tests/dotnet/TestShape.cs
+++ b/tests/dotnet/TestShape.cs
@@ -1,12 +1,12 @@
+using NUnit.Framework;
 using Shape_c;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace TestFFIG
 {
-    [TestClass]
+    [TestFixture]
     public class TestShape
     {
-        [TestMethod]
+        [Test]
         public void CircleName()
         {
           double radius = 2.0;
@@ -15,7 +15,7 @@ namespace TestFFIG
           Assert.AreEqual(circle.name, "Circle");
         }
         
-        [TestMethod]
+        [Test]
         public void CircleArea()
         {
           double radius = 2.0;
@@ -24,7 +24,7 @@ namespace TestFFIG
           Assert.AreEqual(circle.area, 12.56637061436, 10);
         }
         
-        [TestMethod]
+        [Test]
         public void CirclePerimeter()
         {
           double radius = 2.0;
@@ -33,7 +33,7 @@ namespace TestFFIG
           Assert.AreEqual(circle.perimeter, 12.5663706144, 10);
         }
         
-        [TestMethod]
+        [Test]
         public void CircleEquality()
         {
           var circle1 = new Circle(3);
@@ -42,7 +42,7 @@ namespace TestFFIG
           Assert.AreEqual(circle1.is_equal(circle2), 1);
         }
         
-        [TestMethod]
+        [Test]
         public void CircleInequality()
         {
           var circle1 = new Circle(3);

--- a/tests/dotnet/TestTree.cs
+++ b/tests/dotnet/TestTree.cs
@@ -1,12 +1,12 @@
+using NUnit.Framework;
 using Tree_c;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace TestFFIG
 {
-    [TestClass]
+    [TestFixture]
     public class TestTree
     {
-        [TestMethod]
+        [Test]
         public void DepthIsAsConstructed()
         {
           var tree = new Tree(1);
@@ -15,7 +15,7 @@ namespace TestFFIG
           Assert.IsNull(tree.left_subtree().left_subtree());
         }
         
-        [TestMethod]
+        [Test]
         public void DataIsAsSet()
         {
           var tree = new Tree(1);
@@ -25,7 +25,7 @@ namespace TestFFIG
           Assert.AreEqual(tree.data(), 42);
         }
         
-        [TestMethod]
+        [Test]
         public void LifetimeExtension()
         {
           var tree = new Tree(1);

--- a/tests/dotnet/ffig.net.csproj.in
+++ b/tests/dotnet/ffig.net.csproj.in
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
+    <PackageReference Include="nunit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## What does this PR do? 
Changes dotnet tests to use NUnit rather than MSTest

This is related to #349. Perhaps the lower-level commands from mono will give us a faster build?
