### PR TITLE
Dev jbcoe cmake utils

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 include(ffig)
+include(utils)
 
 include_directories(externals/catch2/single_include)
 include_directories(externals/variant/include)
@@ -275,24 +276,6 @@ if(dotnet_FOUND)
   )
   add_dependencies(TestTree.net Tree.net)
 
-  function(ffig_set_test_shared_library_path)
-    set(options)
-    set(multiValueArgs)
-    set(oneValueArgs TEST_NAME DLL_PATH)
-    cmake_parse_arguments(ffig_set_test_shared_library_path "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
-
-    set(TEST_NAME ${ffig_set_test_shared_library_path_TEST_NAME})
-    set(DLL_PATH ${ffig_set_test_shared_library_path_DLL_PATH})
-  
-    if(WIN32)
-      file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/generated FFIG_DLL_PATH)
-      set_property(TEST ${TEST_NAME} 
-        PROPERTY ENVIRONMENT "PATH=${DLL_PATH}\;%PATH%")
-    else()
-      set_property(TEST ${TEST_NAME} 
-        PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${DLL_PATH}:$LD_LIBRARY_PATH")
-    endif()
-  endfunction()
   
   add_test(
     NAME test_shape_dotnet
@@ -300,7 +283,7 @@ if(dotnet_FOUND)
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/generated/TestShape.net)
   set_property(TEST test_shape_dotnet 
                PROPERTY LABELS DOTNET)
-  ffig_set_test_shared_library_path(
+  set_test_shared_library_path(
     TEST_NAME test_shape_dotnet 
     DLL_PATH ${CMAKE_CURRENT_BINARY_DIR}/generated)
 
@@ -310,7 +293,7 @@ if(dotnet_FOUND)
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/generated/TestNumber.net)
   set_property(TEST test_number_dotnet 
                PROPERTY LABELS DOTNET)
-  ffig_set_test_shared_library_path(
+  set_test_shared_library_path(
     TEST_NAME test_number_dotnet 
     DLL_PATH ${CMAKE_CURRENT_BINARY_DIR}/generated)
   
@@ -320,7 +303,7 @@ if(dotnet_FOUND)
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/generated/TestTree.net)
   set_property(TEST test_tree_dotnet 
                PROPERTY LABELS DOTNET)
-  ffig_set_test_shared_library_path(
+  set_test_shared_library_path(
     TEST_NAME test_tree_dotnet 
     DLL_PATH ${CMAKE_CURRENT_BINARY_DIR}/generated)
 

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -1,0 +1,22 @@
+# Utility functions for CMake used by FFIG.
+
+# Set the shared library path for test execution.
+function(set_test_shared_library_path)
+  set(options)
+  set(multiValueArgs)
+  set(oneValueArgs TEST_NAME DLL_PATH)
+  cmake_parse_arguments(set_test_shared_library_path "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  set(TEST_NAME ${set_test_shared_library_path_TEST_NAME})
+  set(DLL_PATH ${set_test_shared_library_path_DLL_PATH})
+
+  if(WIN32)
+    file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/generated FFIG_DLL_PATH)
+    set_property(TEST ${TEST_NAME} 
+      PROPERTY ENVIRONMENT "PATH=${DLL_PATH}\;%PATH%")
+  else()
+    set_property(TEST ${TEST_NAME} 
+      PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${DLL_PATH}:$LD_LIBRARY_PATH")
+  endif()
+endfunction()
+

--- a/cmake/utils.cmake
+++ b/cmake/utils.cmake
@@ -11,7 +11,6 @@ function(set_test_shared_library_path)
   set(DLL_PATH ${set_test_shared_library_path_DLL_PATH})
 
   if(WIN32)
-    file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/generated FFIG_DLL_PATH)
     set_property(TEST ${TEST_NAME} 
       PROPERTY ENVIRONMENT "PATH=${DLL_PATH}\;%PATH%")
   else()


### PR DESCRIPTION
## What does this PR do? 
Moves cmake functions into a utils.cmake file.

This is general cleanup and could be upstreamed to CMake.