### PR TITLE
Move (most) FFIG-specific build logic into cmake/ffig.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,9 @@ else()
   add_compile_options("-std=c++14")
 endif()
 
+set(FFIG_JAR_PATH ${CMAKE_CURRENT_SOURCE_DIR}/externals/ffig-jars)
+set(FFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
+
 if(NOT WIN32)
   set(CMAKE_CXX_FLAGS_ASAN "-g -fno-omit-frame-pointer -O0 -fsanitize=address")
   set(CMAKE_C_FLAGS_ASAN "-g -fno-omit-frame-pointer -O0 -fsanitize=address")
@@ -476,8 +479,6 @@ if(Swift_FOUND)
 endif()
 
 if(Java_FOUND)
-  set(FFIG_JAR_PATH ${CMAKE_CURRENT_SOURCE_DIR}/externals/ffig-jars)
-
   find_jar(JNA_JAR NAMES jna jna-4.5.1 PATHS ${FFIG_JAR_PATH})
   if(NOT JNA_JAR)
     message(FATAL_ERROR
@@ -500,15 +501,6 @@ if(Java_FOUND)
   endif()
 
   # FIXME: Move JAR creation to ffig.cmake - requires passing JAR_PATH.
-  FILE(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/generated/java/classes/Asset")
-  add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/generated/Asset.jar
-    COMMAND ${Java_JAVAC_EXECUTABLE} 
-            -d ${CMAKE_CURRENT_BINARY_DIR}/generated/java/classes/Asset -cp ${CMAKE_CURRENT_LIST_DIR}/externals/ffig-jars/jna.jar ${CMAKE_CURRENT_BINARY_DIR}/generated/java/src/Asset/*.java
-    COMMAND ${Java_JAR_EXECUTABLE} -cfM Asset.jar -C ${CMAKE_BINARY_DIR}/generated/java/classes/Asset .
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/generated
-    DEPENDS Asset_c)
-  add_custom_target(Asset_jar ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/generated/Asset.jar)
   
   add_jar(TestAsset
           tests/java/TestAsset.java
@@ -518,16 +510,6 @@ if(Java_FOUND)
             ${JUNIT_JAR}
             ${CMAKE_CURRENT_BINARY_DIR}/generated/Asset.jar)
   
-  FILE(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/generated/java/classes/Shape")
-  add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/generated/Shape.jar
-    COMMAND ${Java_JAVAC_EXECUTABLE} 
-            -d ${CMAKE_CURRENT_BINARY_DIR}/generated/java/classes/Shape -cp ${CMAKE_CURRENT_LIST_DIR}/externals/ffig-jars/jna.jar ${CMAKE_CURRENT_BINARY_DIR}/generated/java/src/Shape/*.java
-    COMMAND ${Java_JAR_EXECUTABLE} -cfM Shape.jar -C ${CMAKE_BINARY_DIR}/generated/java/classes/Shape .
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/generated
-    DEPENDS Shape_c)
-  add_custom_target(Shape_jar ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/generated/Shape.jar)
-  
   add_jar(TestShape
           tests/java/TestShape.java
           OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/generated
@@ -535,16 +517,6 @@ if(Java_FOUND)
             ${JNA_JAR}
             ${JUNIT_JAR}
             ${CMAKE_CURRENT_BINARY_DIR}/generated/Shape.jar)
-  
-  FILE(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/generated/java/classes/Tree")
-  add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/generated/Tree.jar
-    COMMAND ${Java_JAVAC_EXECUTABLE} 
-            -d ${CMAKE_CURRENT_BINARY_DIR}/generated/java/classes/Tree -cp ${CMAKE_CURRENT_LIST_DIR}/externals/ffig-jars/jna.jar ${CMAKE_CURRENT_BINARY_DIR}/generated/java/src/Tree/*.java
-    COMMAND ${Java_JAR_EXECUTABLE} -cfM Tree.jar -C ${CMAKE_BINARY_DIR}/generated/java/classes/Tree .
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/generated
-    DEPENDS Tree_c)
-  add_custom_target(Tree_jar ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/generated/Tree.jar)
   
   add_jar(TestTree
           tests/java/TestTree.java
@@ -554,16 +526,6 @@ if(Java_FOUND)
             ${JUNIT_JAR}
             ${CMAKE_CURRENT_BINARY_DIR}/generated/Tree.jar)
   
-  FILE(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/generated/java/classes/Number")
-  add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/generated/Number.jar
-    COMMAND ${Java_JAVAC_EXECUTABLE} 
-            -d ${CMAKE_CURRENT_BINARY_DIR}/generated/java/classes/Number -cp ${CMAKE_CURRENT_LIST_DIR}/externals/ffig-jars/jna.jar ${CMAKE_CURRENT_BINARY_DIR}/generated/java/src/Number/*.java
-    COMMAND ${Java_JAR_EXECUTABLE} -cfM Number.jar -C ${CMAKE_BINARY_DIR}/generated/java/classes/Number .
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/generated
-    DEPENDS Number_c)
-  add_custom_target(Number_jar ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/generated/Number.jar)
-  
   add_jar(TestNumber
           tests/java/TestNumber.java
           OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/generated
@@ -572,14 +534,14 @@ if(Java_FOUND)
             ${JUNIT_JAR}
             ${CMAKE_CURRENT_BINARY_DIR}/generated/Number.jar)
 
-  list(APPEND JAVA_JARS
-       ${JNA_JAR}
-       ${JUNIT_JAR}
-       ${HAMCREST_JAR}
-       ${CMAKE_CURRENT_BINARY_DIR}/generated/Asset.jar
-       ${CMAKE_CURRENT_BINARY_DIR}/generated/Number.jar
-       ${CMAKE_CURRENT_BINARY_DIR}/generated/Shape.jar
-       ${CMAKE_CURRENT_BINARY_DIR}/generated/Tree.jar)
+# list(APPEND JAVA_JARS
+#      ${JNA_JAR}
+#      ${JUNIT_JAR}
+#      ${HAMCREST_JAR}
+#      ${CMAKE_CURRENT_BINARY_DIR}/generated/Asset.jar
+#      ${CMAKE_CURRENT_BINARY_DIR}/generated/Number.jar
+#      ${CMAKE_CURRENT_BINARY_DIR}/generated/Shape.jar
+#      ${CMAKE_CURRENT_BINARY_DIR}/generated/Tree.jar)
 
   #FIXME: Use JOIN when CMake 3.12 is available.
   if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ else()
   add_compile_options("-std=c++14")
 endif()
 
+set(FFIG_JNA_JAR_PATH ${CMAKE_CURRENT_SOURCE_DIR}/externals/ffig-jars/jna.jar)
 set(FFIG_JAR_PATH ${CMAKE_CURRENT_SOURCE_DIR}/externals/ffig-jars)
 set(FFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
 
@@ -499,8 +500,6 @@ if(Java_FOUND)
       "Could NOT find Hamcrest library. "
       "Run git submodule update --init to get JARs")
   endif()
-
-  # FIXME: Move JAR creation to ffig.cmake - requires passing JAR_PATH.
   
   add_jar(TestAsset
           tests/java/TestAsset.java
@@ -551,8 +550,6 @@ if(Java_FOUND)
     #list(JOIN ${JAVA_JARS} : JAVA_CLASSPATH)
     set(JAVA_CLASSPATH "TestAsset.jar:Asset.jar:TestShape.jar:Shape.jar:TestNumber.jar:Number.jar:TestTree.jar:Tree.jar:${JNA_JAR}:${JUNIT_JAR}:${HAMCREST_JAR}")
   endif()
-
-  message(STATUS "${Java_JAVA_EXECUTABLE} -classpath ${JAVA_CLASSPATH} org.junit.runner.JUnitCore TestAsset")
 
   add_test(
     NAME test_java_asset
@@ -624,21 +621,6 @@ if(Go_FOUND AND NOT WIN32)
 endif()
 
 if(BOOST_PYTHON_Found)
-  add_library(Shape_py SHARED ${CMAKE_CURRENT_BINARY_DIR}/generated/Shape_py.cpp)
-  target_include_directories(Shape_py PRIVATE ${PYTHON_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
-  target_link_libraries(Shape_py ${PYTHON_LIBRARIES})
-  target_link_libraries(Shape_py ${Boost_LIBRARIES})
-  set_property(TARGET Shape_py PROPERTY PREFIX "")
-  if(WIN32)
-    set_property(TARGET Shape_py PROPERTY SUFFIX ".dll")
-  else()
-    set_property(TARGET Shape_py PROPERTY SUFFIX ".so")
-  endif()
-
-  add_custom_command(TARGET Shape_py
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:Shape_py> ${CMAKE_CURRENT_BINARY_DIR}/generated)
-
   # FIXME: Use the existing Python tests with boost::python.
   add_test(
     NAME test_boost_python_bindings

--- a/cmake/ffig.cmake
+++ b/cmake/ffig.cmake
@@ -34,6 +34,7 @@ function(ffig_add_library)
   cmake_parse_arguments(ffig_add_library "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
   set(module ${ffig_add_library_NAME})
+  string(TOLOWER "${module}" module_lower)
   set(input ${ffig_add_library_INPUTS})
 
   # Always generate c-api bindings as all other bindings use them.
@@ -41,28 +42,9 @@ function(ffig_add_library)
   set(ffig_invocation "-i;${input};-m;${module};-o;${ffig_output_dir};-b;_c.h.tmpl;_c.cpp.tmpl")
   set(ffig_outputs "${ffig_output_dir}/${module}_c.h;${ffig_output_dir}/${module}_c.cpp")  
 
-  if(ffig_add_library_BOOST_PYTHON)
-    set(ffig_invocation "${ffig_invocation};boost_python")
-    set(ffig_outputs "${ffig_outputs};${ffig_output_dir}/${module}_py.cpp")
-  endif()
-  if(ffig_add_library_RUBY)
-    set(ffig_invocation "${ffig_invocation};ruby")
-    set(ffig_outputs "${ffig_outputs};${ffig_output_dir}/${module}.rb")
-  endif()
-  if(ffig_add_library_LUA)
-    set(ffig_invocation "${ffig_invocation};lua")
-    set(ffig_outputs "${ffig_outputs};${ffig_output_dir}/${module}.lua")
-  endif()
   if(ffig_add_library_DOTNET)
     set(ffig_invocation "${ffig_invocation};dotnet")
     set(ffig_outputs "${ffig_outputs};${ffig_output_dir}/${module}.cs")
-  endif()
-  if(ffig_add_library_PYTHON)
-    set(ffig_invocation "${ffig_invocation};python")
-    string(TOLOWER "${module}" module_lower)
-    set(ffig_outputs "${ffig_outputs};${ffig_output_dir}/${module_lower}/__init__.py")
-    set(ffig_outputs "${ffig_outputs};${ffig_output_dir}/${module_lower}/_py2.py")
-    set(ffig_outputs "${ffig_outputs};${ffig_output_dir}/${module_lower}/_py3.py")
   endif()
   if(ffig_add_library_CPP_MOCKS)
     set(ffig_invocation "${ffig_invocation};_mocks.h.tmpl")
@@ -89,50 +71,134 @@ function(ffig_add_library)
     COMMAND ${PYTHON_EXECUTABLE} -m ffig ${ffig_invocation}
     DEPENDS ${input} ${FFIG_SOURCE}
     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-    COMMENT "Generating FFIG bindings for ${input}: ${ffig_outputs}")
+    COMMENT "Generating FFIG bindings for ${module}: ${ffig_outputs}")
 
   # FIXME: This is a bit ugly. The header is copied next to the generated bindings.
   file(COPY ${input} DESTINATION ${ffig_output_dir}/)
 
   add_library(${module}_c SHARED ${input} ${ffig_output_dir}/${module}_c.h ${ffig_output_dir}/${module}_c.cpp)
+  set_target_properties(${module}_c PROPERTIES 
+    LIBRARY_OUTPUT_DIRECTORY ${ffig_output_dir})
 
-  # FIXME: This is a bit ugly. The shared library is copied next to the generated bindings.
-  add_custom_command(TARGET ${module}_c
-    POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${module}_c> ${ffig_output_dir}/)
-
+  #
+  # Ruby bindings
+  #
+  if(ffig_add_library_RUBY)
+    add_custom_command(
+      OUTPUT ${ffig_output_dir}/${module}.rb
+      COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module} -o ${ffig_output_dir} -b ruby
+      DEPENDS ${input} ${FFIG_SOURCE}
+      WORKING_DIRECTORY ${FFIG_ROOT}
+      COMMENT "Generating Ruby bindings for ${module}")
+    
+    add_custom_target(${module}.ffig.ruby ALL DEPENDS ${ffig_outputs};${ffig_output_dir}/${module}.rb)
+  endif()
+  
+  #
+  # Lua bindings
+  #
+  if(ffig_add_library_LUA)
+    add_custom_command(
+      OUTPUT ${ffig_output_dir}/${module}.lua
+      COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module} -o ${ffig_output_dir} -b lua
+      DEPENDS ${input} ${FFIG_SOURCE}
+      WORKING_DIRECTORY ${FFIG_ROOT}
+      COMMENT "Generating LuaJIT bindings for ${module}")
+    
+    add_custom_target(${module}.ffig.lua ALL DEPENDS ${ffig_outputs};${ffig_output_dir}/${module}.lua)
+  endif()
+  
+  #
+  # Python bindings
+  #
   if(ffig_add_library_PYTHON)
-      # Run pycodestyle on generated Python. Ignore line-length errors,
-      # as with generated code we have no control over the length of
-      # type or function names supplied as input.
-      add_custom_command(TARGET ${module}_c
-          POST_BUILD
-          COMMAND ${PYTHON_EXECUTABLE} -m pycodestyle --ignore=E501 ${ffig_output_dir}/${module_lower}
-          DEPENDS ${ffig_outputs})
+    # Run FFIG to generate Python bindings,
+    # Run pycodestyle on generated Python. Ignore line-length errors,
+    # as with generated code we have no control over the length of
+    # type or function names supplied as input.
+    add_custom_command(
+      OUTPUT ${ffig_output_dir}/${module_lower}/__init__.py 
+             ${ffig_output_dir}/${module_lower}/_py2.py 
+             ${ffig_output_dir}/${module_lower}/_py3.py
+      COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module} -o ${ffig_output_dir} -b python
+      COMMAND ${PYTHON_EXECUTABLE} -m pycodestyle --ignore=E501 ${ffig_output_dir}/${module_lower}
+      DEPENDS ${input} ${FFIG_SOURCE}
+      WORKING_DIRECTORY ${FFIG_ROOT}
+      COMMENT "Generating Python bindings for ${module}")
+    
+    add_custom_target(${module}.ffig.python ALL 
+      DEPENDS ${ffig_output_dir}/${module_lower}/__init__.py 
+              ${ffig_output_dir}/${module_lower}/_py2.py 
+              ${ffig_output_dir}/${module_lower}/_py3.py)
   endif()
 
-  if(ffig_add_library_JAVA)  
+  #
+  # Java bindings
+  #
+  # FIXME: Do not check Java_FOUND. 
+  # Requesting Java bindings with no Java SDK is user-error.
+  if(ffig_add_library_JAVA AND Java_FOUND)  
     FILE(MAKE_DIRECTORY "${ffig_output_dir}/java/classes/${module}")
     
     add_custom_command(
       OUTPUT ${ffig_output_dir}/java/src/${module}/${module}CLibrary.java
-      COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module} -o ${ffig_output_dir} -b java
+      COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module} 
+              -o ${ffig_output_dir} -b java
       DEPENDS ${input} ${FFIG_SOURCE}
       WORKING_DIRECTORY ${FFIG_ROOT}
-      COMMENT "Generating ${module} java source for ${input}")
+      COMMENT "Generating java source for ${module}")
     
-    add_custom_target(${module}.ffig.java.source DEPENDS ${ffig_output_dir}/java/src/${module}/${module}CLibrary.java)
+    add_custom_target(${module}.ffig.java.source 
+      DEPENDS ${ffig_output_dir}/java/src/${module}/${module}CLibrary.java)
   
     add_custom_command(
       OUTPUT ${ffig_output_dir}/${module}.jar
       COMMAND ${Java_JAVAC_EXECUTABLE} 
-      -d ${ffig_output_dir}/java/classes/${module} -cp ${FFIG_JAR_PATH}/jna.jar ${ffig_output_dir}/java/src/${module}/*.java
-      COMMAND ${Java_JAR_EXECUTABLE} -cfM ${module}.jar -C ${ffig_output_dir}/java/classes/${module} .
+              -d ${ffig_output_dir}/java/classes/${module} 
+              -cp ${FFIG_JNA_JAR_PATH}
+              ${ffig_output_dir}/java/src/${module}/*.java
+      COMMAND ${Java_JAR_EXECUTABLE} -cfM ${module}.jar 
+              -C ${ffig_output_dir}/java/classes/${module} .
       WORKING_DIRECTORY ${ffig_output_dir}
       DEPENDS ${module}.ffig.java.source
       COMMENT "Building ${module}.jar from FFIG source bindings.")
     
-    add_custom_target(${module}.ffig.java DEPENDS ${ffig_output_dir}/${module}.jar)
+    add_custom_target(${module}.ffig.java ALL 
+      DEPENDS ${ffig_output_dir}/${module}.jar)
+  endif()
+  
+  #
+  # boost::python bindings
+  #
+  # FIXME: Do not check BOOST_PYTHON_FOUND. 
+  # Requesting boost::python bindings with no boost::python libs is user-error.
+  if(ffig_add_library_BOOST_PYTHON AND BOOST_PYTHON_Found)
+    add_custom_command(
+      OUTPUT ${ffig_output_dir}/${module}_py.cpp
+      COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module} 
+              -o ${ffig_output_dir} -b boost_python
+      DEPENDS ${input} ${FFIG_SOURCE}
+      WORKING_DIRECTORY ${FFIG_ROOT}
+      COMMENT "Generating boost::python source for ${module}")
+    
+    add_custom_target(${module}.ffig.boost_python.source 
+      DEPENDS ${ffig_output_dir}/${module}_py.cpp)
+  
+    add_library(${module}_py SHARED 
+      ${CMAKE_CURRENT_BINARY_DIR}/generated/${module}_py.cpp)
+    target_include_directories(${module}_py 
+      PRIVATE ${PYTHON_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+    target_link_libraries(${module}_py ${PYTHON_LIBRARIES})
+    target_link_libraries(${module}_py ${Boost_LIBRARIES})
+    set_property(TARGET ${module}_py PROPERTY PREFIX "")
+    if(WIN32)
+      set_property(TARGET ${module}_py PROPERTY SUFFIX ".dll")
+    else()
+      set_property(TARGET ${module}_py PROPERTY SUFFIX ".so")
+    endif()
+
+    set_target_properties(${module}_py PROPERTIES 
+      LIBRARY_OUTPUT_DIRECTORY ${ffig_output_dir})
   endif()
 
 endfunction()

--- a/ffig/FFIG.py
+++ b/ffig/FFIG.py
@@ -76,7 +76,6 @@ def write_bindings_to_disk(
     - output_dir where to write to
     """
 
-    bindings.extend("_c.cpp.tmpl _c.h.tmpl".split())
     bindings = list(set(bindings))
 
     for binding in bindings:


### PR DESCRIPTION
## What does this PR do? 
Moves (most)  FFIG-specific build logic into cmake/ffig.cmake

## Possible future work
* Clean up the last of the build logic.
* Add targets for each FFIG binding `add_ffig_ruby_library` etc.