### PR TITLE
Added a file for boost::python Shape tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -624,8 +624,9 @@ if(BOOST_PYTHON_Found)
   # FIXME: Use the existing Python tests with boost::python.
   add_test(
     NAME test_boost_python_bindings
-    COMMAND python -c "import Shape_py; c = Shape_py.Circle(3); print('A %s with radius 3 has area %f' % (c.name, c.area))"
+    COMMAND ${PYTHON_EXECUTABLE} -m nose -v ${CMAKE_CURRENT_LIST_DIR}/tests/boost_python
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/generated)
-  set_property(TEST test_boost_python_bindings PROPERTY LABELS BOOST_PYTHON)
+  set_property(TEST test_boost_python_bindings
+    PROPERTY LABELS BOOST_PYTHON)
 endif()
 

--- a/tests/boost_python/test_shape_python_bindings.py
+++ b/tests/boost_python/test_shape_python_bindings.py
@@ -1,0 +1,22 @@
+import math
+import nose
+import Shape_py as shape
+
+
+def test_shape_Circle_is_called_Circle():
+    c = shape.Circle(3)
+    assert c.name == "Circle"
+
+
+def test_shape_Circle_has_expected_area():
+    r = 2.0
+    c = shape.Circle(r)
+    a = math.pi * r * r
+    nose.tools.assert_almost_equal(c.area, a)
+
+
+def test_shape_Circle_has_expected_perimeter():
+    r = 2.0
+    c = shape.Circle(r)
+    p = 2.0 * math.pi * r
+    nose.tools.assert_almost_equal(c.perimeter, p)


### PR DESCRIPTION
## What does this PR do? 
Adds a test for boost::python bindings for Shape.

## Ideas that were considered and discarded
Generating tests from the existing python tests might be a good idea later but we don't support enough of the tested python functionality with boost::python bindings yet.

## Possible future work
Add more tests for extra functionality.