### PR TITLE
Add dotnet generator

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,4 +7,4 @@ install:
   - cmd: C:\Python36-x64\python -m pip install jinja2 nose pycodestyle
   
 build_script:
-  - cmd: python scripts\build.py -t --python-path "C:\\Python36-x64\\python" --disable_java --require_dotnet
+  - cmd: python scripts\build.py -t --python-path "C:\\Python36-x64\\python" --disable_java --disable_dotnet

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,4 +7,4 @@ install:
   - cmd: C:\Python36-x64\python -m pip install jinja2 nose pycodestyle
   
 build_script:
-  - cmd: python scripts\build.py -t --python-path "C:\\Python36-x64\\python" --disable_java --disable_dotnet
+  - cmd: python scripts\build.py -t --python-path "C:\\Python36-x64\\python" --disable_java --require_dotnet

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,14 +29,13 @@ matrix:
       install:
         - brew update
         - brew install ninja && brew upgrade python && brew install python@2
-        - brew cask install caskroom/cask/dotnet
         - /usr/local/opt/python@2/bin/pip2 install --user --upgrade pip
         - /usr/local/opt/python@2/bin/pip2 install --user jinja2 nose pycodestyle
         - pip3 install --user --upgrade pip && pip3 install --user jinja2 nose pycodestyle
         - gem install ffi
       script:
-        - ./scripts/build.py -t
-        - ./scripts/build.py -t --python-path python3
+        - ./scripts/build.py -t --disable_boost_python --disable_dotnet
+        - ./scripts/build.py -t --disable_boost_python --disable_dotnet --python-path python3
 
 notifications:
   slack:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 set(FFIG_JNA_JAR_PATH ${CMAKE_CURRENT_SOURCE_DIR}/externals/ffig-jars/jna.jar)
 set(FFIG_JAR_PATH ${CMAKE_CURRENT_SOURCE_DIR}/externals/ffig-jars)
 set(FFIG_ROOT ${CMAKE_CURRENT_SOURCE_DIR})
+set(CMAKE_DOTNET_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/generated)
 
 if(NOT WIN32)
   set(CMAKE_CXX_FLAGS_ASAN "-g -fno-omit-frame-pointer -O0 -fsanitize=address")
@@ -23,8 +24,9 @@ if(NOT WIN32)
 endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
-include(ffig)
 include(utils)
+include(dotnet)
+include(ffig)
 
 include_directories(externals/catch2/single_include)
 include_directories(externals/variant/include)
@@ -346,26 +348,6 @@ set_property(TEST test_cpp_tree
              PROPERTY LABELS CPP)
 
 if(dotnet_FOUND)
-  include(dotnet)
-  set(CMAKE_DOTNET_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/generated)
-
-  add_dotnet_project(NAME Shape.net
-    DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/tests/dotnet/Shape
-    SOURCES
-    ${CMAKE_CURRENT_BINARY_DIR}/generated/Shape.cs
-  )
-
-  add_dotnet_project(NAME Tree.net
-    DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/tests/dotnet/Tree
-    SOURCES
-    ${CMAKE_CURRENT_BINARY_DIR}/generated/Tree.cs
-  )
-
-  add_dotnet_project(NAME Number.net
-    DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/tests/dotnet/Number
-    SOURCES
-    ${CMAKE_CURRENT_BINARY_DIR}/generated/Number.cs
-  )
 
   add_dotnet_project(NAME TestShape.net
     DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/tests/dotnet/TestShape

--- a/cmake/ffig.cmake
+++ b/cmake/ffig.cmake
@@ -218,7 +218,9 @@ function(ffig_add_library)
       DEPENDS ${ffig_output_dir}/${module}.jl)
   endif()
   
-  if(ffig_add_library_DOTNET)
+  # FIXME: Do not check dotnet_FOUND. 
+  # Requesting dotnet bindings with no dotnet is user-error.
+  if(ffig_add_library_DOTNET AND dotnet_FOUND)
     add_custom_command(
       OUTPUT ${ffig_output_dir}/${module}.net/${module}.cs ${ffig_output_dir}/${module}.net/${module}.net.csproj
       COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module} -o ${ffig_output_dir} -b dotnet

--- a/cmake/ffig.cmake
+++ b/cmake/ffig.cmake
@@ -231,9 +231,14 @@ function(ffig_add_library)
     add_custom_target(${module}.ffig.net.source ALL
       DEPENDS ${ffig_output_dir}/${module}.net/${module}.cs ${ffig_output_dir}/${module}.net/${module}.net.csproj)
   
-    add_dotnet_project(NAME ${module}.net
-      DIRECTORY ${ffig_output_dir}/${module}.net
-      SOURCES ${ffig_output_dir}/${module}.net/${module}.cs)
+    # Invoke dotnet directly as add_dotnet_project contains a copy which does not get ordered correctly.
+    # FIXME: Work out why the copy performed by add_dotnet_project is incorrectly ordered on Windows.
+    add_custom_command(
+      OUTPUT ${module}.net.dll
+      COMMAND dotnet build -o .
+      WORKING_DIRECTORY ${ffig_output_dir}/${module}.net)
+
+    add_custom_target(${module}.net DEPENDS ${module}.net.dll)
 
     add_dependencies(${module}.net ${module}.ffig.net.source)
   endif()

--- a/cmake/ffig.cmake
+++ b/cmake/ffig.cmake
@@ -234,6 +234,8 @@ function(ffig_add_library)
     add_dotnet_project(NAME ${module}.net
       DIRECTORY ${ffig_output_dir}/${module}.net
       SOURCES ${ffig_output_dir}/${module}.net/${module}.cs)
+
+    add_dependencies(${module}.net ${module}.ffig.net.source)
   endif()
 
 endfunction()

--- a/cmake/ffig.cmake
+++ b/cmake/ffig.cmake
@@ -42,10 +42,6 @@ function(ffig_add_library)
   set(ffig_invocation "-i;${input};-m;${module};-o;${ffig_output_dir};-b;_c.h.tmpl;_c.cpp.tmpl")
   set(ffig_outputs "${ffig_output_dir}/${module}_c.h;${ffig_output_dir}/${module}_c.cpp")  
 
-  if(ffig_add_library_DOTNET)
-    set(ffig_invocation "${ffig_invocation};dotnet")
-    set(ffig_outputs "${ffig_outputs};${ffig_output_dir}/${module}.cs")
-  endif()
   if(ffig_add_library_CPP_MOCKS)
     set(ffig_invocation "${ffig_invocation};_mocks.h.tmpl")
     set(ffig_outputs "${ffig_outputs};${ffig_output_dir}/${module}_mocks.h")
@@ -220,6 +216,22 @@ function(ffig_add_library)
 
     add_custom_target(${module}.ffig.julia.source ALL
       DEPENDS ${ffig_output_dir}/${module}.jl)
+  endif()
+  
+  if(ffig_add_library_DOTNET)
+    add_custom_command(
+      OUTPUT ${ffig_output_dir}/${module}.net/${module}.cs ${ffig_output_dir}/${module}.net/${module}.net.csproj
+      COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module} -o ${ffig_output_dir} -b dotnet
+      DEPENDS ${input} ${FFIG_SOURCE}
+      WORKING_DIRECTORY ${FFIG_ROOT}
+      COMMENT "Generating C# source for ${module}")
+
+    add_custom_target(${module}.ffig.net.source ALL
+      DEPENDS ${ffig_output_dir}/${module}.net/${module}.cs ${ffig_output_dir}/${module}.net/${module}.net.csproj)
+  
+    add_dotnet_project(NAME ${module}.net
+      DIRECTORY ${ffig_output_dir}/${module}.net
+      SOURCES ${ffig_output_dir}/${module}.net/${module}.cs)
   endif()
 
 endfunction()

--- a/ffig/generators/dotnet.py
+++ b/ffig/generators/dotnet.py
@@ -1,0 +1,33 @@
+# Generator module for dotnet.
+
+import ffig.generators
+import os
+import shutil
+
+def generator(module_name, binding, api_classes, env, output_dir):
+    outputs = []
+
+    output_dir = os.path.join(output_dir, module_name + '.net')
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    o = os.path.join(output_dir, module_name + '.cs')
+    ffig.generators.generate_single_output_file(
+        module_name, 'cs.tmpl', api_classes, env, o)
+    outputs.append(o)
+
+    o = os.path.join(output_dir, module_name + '.net.csproj')
+    ffig.generators.generate_single_output_file(
+        module_name, 'csproj.tmpl', api_classes, env, o)
+    outputs.append(o)
+    
+    return outputs
+
+
+def setup_plugin(context):
+    context.register(
+            generator,
+            [
+                ('dotnet', 'dotnet generator using PInvoke')
+            ])
+

--- a/ffig/generators/generator_aliases.py
+++ b/ffig/generators/generator_aliases.py
@@ -4,7 +4,6 @@
 import ffig.generators
 
 aliases = {
-    'dotnet': ('cs.tmpl', 'dotnet (C#) bindings'),
     'julia': ('jl.tmpl', 'Julia bindings'),
     'lua': ('lua.tmpl', 'Lua bindings'),
     'ruby': ('rb.tmpl', 'Ruby bindings'),

--- a/ffig/templates/csproj.tmpl
+++ b/ffig/templates/csproj.tmpl
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/ffig/templates/csproj.tmpl
+++ b/ffig/templates/csproj.tmpl
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>


### PR DESCRIPTION
## What does this PR do? 
Add generator for dotnet bindings. Generator creates project file for
generated source in {module}.net directory. ffig.cmake now adds targets
for generated dotnet assemblies.

## Closes [github issues]
closes #438