### PR TITLE
Add test for compile errors in parsed source file.

### DIFF
--- a/ffig/FFIG.py
+++ b/ffig/FFIG.py
@@ -100,7 +100,8 @@ def build_model_from_source(
     ffig_include_dir = os.path.join(os.path.dirname(__file__), 'include')
     tu = clang.cindex.TranslationUnit.from_source(
         path_to_source,
-        '-x c++ -std=c++14 -stdlib=libc++ -I{}'.format(ffig_include_dir).split(),
+        '-x c++ -std=c++14 -stdlib=libc++ -I{}'.format(
+            ffig_include_dir).split(),
         unsaved_files=unsaved_files)
 
     model = ffig.cppmodel.Model(tu)

--- a/tests/cppmodel/test_classes.py
+++ b/tests/cppmodel/test_classes.py
@@ -142,7 +142,7 @@ def test_class_member_data():
     class A {};
     class B {
         int x_;
-        B b_;
+        A a_;
     };
     """
 
@@ -156,8 +156,8 @@ def test_class_member_data():
     assert c.members[0].name == "x_"
 
     assert c.members[1].type.kind == TypeKind.RECORD
-    assert c.members[1].type.name == "B"
-    assert c.members[1].name == "b_"
+    assert c.members[1].type.name == "A"
+    assert c.members[1].name == "a_"
 
 
 def test_string_representation():

--- a/tests/cppmodel/test_model.py
+++ b/tests/cppmodel/test_model.py
@@ -1,6 +1,7 @@
 from util import get_tu
 import ffig.cppmodel
 from nose.tools import assert_equals
+from nose.tools import assert_raises
 
 
 def test_repr():
@@ -12,3 +13,12 @@ def test_repr():
     assert_equals(
         str(model),
         "<cppmodel.Model filename=t.cpp, classes=['A'], functions=['foo']>")
+
+
+def test_exception_for_missing_include():
+    source = '#include "major_tom.h"'
+    tu = get_tu(source, 'cpp')
+
+    def f():
+        ffig.cppmodel.Model(tu)
+    assert_raises(ValueError, f)


### PR DESCRIPTION
## What does this PR do? 
Causes cppmodel to fail if the parsed file contains errors.

## Closes [github issues]
#453 

## Possible future work
More work is needed to fail for compile errors in transitively included headers. (Causes test failures on macOS) #458