### PR TITLE
use build_out for default build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ demos/Shape_cpp.h
 demos/Shape_mocks.h
 demos/cmake_install.cmake
 demos/libShape_c.dylib
-build
+build_out
 .vscode/tags
 *.iml
 .idea/

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -51,7 +51,7 @@ def main():
     parser.add_argument(
         '-o',
         help='output dir (relative to source dir)',
-        default='build',
+        default='build_out',
         dest='out_dir')
     parser.add_argument(
         '-c',

--- a/tests/TestShape.rb
+++ b/tests/TestShape.rb
@@ -1,6 +1,6 @@
 require "test/unit"
 # FIXME: Remove this hardcoded path
-require_relative "../build/generated/Shape"
+require_relative "../build_out/generated/Shape"
 
 class TestShape < Test::Unit::TestCase
   def test_name

--- a/tests/julia/TestShape.jl
+++ b/tests/julia/TestShape.jl
@@ -1,6 +1,6 @@
 using Base.Test
 
-include("../../build/generated/Shape.jl")
+include("../../build_out/generated/Shape.jl")
 using FFIG
 
 @test area(Square(3.0)) == 9.0


### PR DESCRIPTION
BUILD is used by Bazel so build will be used for build config on case insensitive systems.
