### PR TITLE
N091 generate Rust bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,7 +222,7 @@ if(NOT FFIG_DISABLE_BOOST_PYTHON)
   if(NOT PythonLibs_FOUND)
     if(FFIG_REQUIRE_BOOST_PYTHON)
       message(FATAL_ERROR "CMake failed: Python libraries not found but are required by this build.")
-    else()  
+    else()
       message(STATUS "boost::python tests disabled: Python libraries not found.")
     endif()
   else()
@@ -234,7 +234,7 @@ if(NOT FFIG_DISABLE_BOOST_PYTHON)
     if(NOT Boost_FOUND)
       if(FFIG_REQUIRE_BOOST_PYTHON)
         message(FATAL_ERROR "CMake failed: Boost libraries not found but are required by this build.")
-      else()  
+      else()
         message(STATUS "boost::python tests disabled: Boost libraries not found.")
       endif()
     else()
@@ -345,7 +345,7 @@ if(dotnet_FOUND)
   ffig_add_dotnet_library(NAME Shape INPUTS tests/input/Shape.h)
   ffig_add_dotnet_library(NAME Tree INPUTS tests/input/Tree.h)
   ffig_add_dotnet_library(NAME Number INPUTS tests/input/Number.h)
-  
+
   add_dotnet_project(NAME TestShape.net
     DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/tests/dotnet/TestShape
     SOURCES
@@ -374,7 +374,7 @@ if(dotnet_FOUND)
   set_property(TEST test_dotnet_shape
                PROPERTY LABELS DOTNET)
   set_test_shared_library_path(
-    TEST_NAME test_dotnet_shape 
+    TEST_NAME test_dotnet_shape
     DLL_PATH ${CMAKE_CURRENT_BINARY_DIR}/generated)
 
   add_test(
@@ -384,7 +384,7 @@ if(dotnet_FOUND)
   set_property(TEST test_dotnet_number
                PROPERTY LABELS DOTNET)
   set_test_shared_library_path(
-    TEST_NAME test_dotnet_number 
+    TEST_NAME test_dotnet_number
     DLL_PATH ${CMAKE_CURRENT_BINARY_DIR}/generated)
 
   add_test(
@@ -394,13 +394,13 @@ if(dotnet_FOUND)
   set_property(TEST test_dotnet_tree
                PROPERTY LABELS DOTNET)
   set_test_shared_library_path(
-    TEST_NAME test_dotnet_tree 
+    TEST_NAME test_dotnet_tree
     DLL_PATH ${CMAKE_CURRENT_BINARY_DIR}/generated)
 
 endif()
 
 if(Swift_FOUND)
-  
+
   ffig_add_swift_library(NAME Shape INPUTS tests/input/Shape.h)
   ffig_add_swift_library(NAME Tree INPUTS tests/input/Tree.h)
 
@@ -493,7 +493,7 @@ if(Java_FOUND)
   ffig_add_java_library(NAME Tree INPUTS tests/input/Tree.h)
   ffig_add_java_library(NAME Number INPUTS tests/input/Number.h)
   ffig_add_java_library(NAME Asset INPUTS tests/input/Asset.h)
-  
+
   find_jar(JNA_JAR NAMES jna jna-4.5.1 PATHS ${FFIG_JAR_PATH})
   if(NOT JNA_JAR)
     message(FATAL_ERROR
@@ -514,7 +514,7 @@ if(Java_FOUND)
       "Could NOT find Hamcrest library. "
       "Run git submodule update --init to get JARs")
   endif()
-  
+
   add_jar(TestAsset
           tests/java/TestAsset.java
           OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/generated
@@ -522,7 +522,7 @@ if(Java_FOUND)
             ${JNA_JAR}
             ${JUNIT_JAR}
             ${CMAKE_CURRENT_BINARY_DIR}/generated/Asset.jar)
-  
+
   add_jar(TestShape
           tests/java/TestShape.java
           OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/generated
@@ -530,7 +530,7 @@ if(Java_FOUND)
             ${JNA_JAR}
             ${JUNIT_JAR}
             ${CMAKE_CURRENT_BINARY_DIR}/generated/Shape.jar)
-  
+
   add_jar(TestTree
           tests/java/TestTree.java
           OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/generated
@@ -538,7 +538,7 @@ if(Java_FOUND)
             ${JNA_JAR}
             ${JUNIT_JAR}
             ${CMAKE_CURRENT_BINARY_DIR}/generated/Tree.jar)
-  
+
   add_jar(TestNumber
           tests/java/TestNumber.java
           OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/generated
@@ -573,7 +573,7 @@ if(Java_FOUND)
     PROPERTY LABELS JAVA)
   set_property(TEST test_java_asset
                 PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}/generated")
-  
+
   add_test(
     NAME test_java_shape
     COMMAND ${Java_JAVA_EXECUTABLE} -classpath ${JAVA_CLASSPATH} org.junit.runner.JUnitCore TestShape
@@ -582,7 +582,7 @@ if(Java_FOUND)
     PROPERTY LABELS JAVA)
   set_property(TEST test_java_shape
                 PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}/generated")
-  
+
   add_test(
     NAME test_java_tree
     COMMAND ${Java_JAVA_EXECUTABLE} -classpath ${JAVA_CLASSPATH} org.junit.runner.JUnitCore TestTree
@@ -612,9 +612,19 @@ add_test(
 set_property(TEST test_d_tree_output
              PROPERTY LABELS D TEXT)
 
+# Unconditionally generate Rust bindings as nothing is (currently) built, just generated.
+ffig_add_rust_library(NAME Tree INPUTS tests/input/Tree.h)
+add_test(
+  NAME test_rust_tree_output
+  COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/scripts/pydiff.py
+  ${CMAKE_CURRENT_LIST_DIR}/tests/expected_output/Tree.rs.expected
+  ${CMAKE_CURRENT_BINARY_DIR}/generated/Tree.rs)
+set_property(TEST test_rust_tree_output
+             PROPERTY LABELS RUST TEXT)
+
 if(LuaJIT_FOUND)
   ffig_add_lua_library(NAME Asset INPUTS tests/input/Asset.h)
-  
+
   add_test(
     NAME test_lua_asset
     COMMAND ${LuaJIT_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/tests/test_asset_bindings.lua
@@ -645,7 +655,7 @@ if(BOOST_PYTHON_Found)
   ffig_add_boost_python_library(NAME Tree INPUTS tests/input/Tree.h)
   ffig_add_boost_python_library(NAME Number INPUTS tests/input/Number.h)
   ffig_add_boost_python_library(NAME Animal INPUTS tests/input/Animal.h)
-  
+
   add_test(
     NAME test_boost_python_bindings
     COMMAND ${PYTHON_EXECUTABLE} -m nose -v ${CMAKE_CURRENT_LIST_DIR}/tests/boost_python
@@ -656,7 +666,7 @@ endif()
 
 if(Julia_FOUND)
   ffig_add_julia_library(NAME Shape INPUTS tests/input/Shape.h)
-  
+
   add_test(
       NAME test_julia_bindings
       COMMAND ${Julia_EXECUTABLE} tests/julia/TestShape.jl

--- a/cmake/ffig.cmake
+++ b/cmake/ffig.cmake
@@ -3,7 +3,7 @@
 #
 # This module defines functions that allow the user to add build targets that
 # create language bindings for a C++ library.
-# 
+#
 # All the bindings depend on a MODULE_NAME_c target produced by `ffig_add_c_library`.
 #
 # Usage:
@@ -43,8 +43,8 @@ function(ffig_add_c_library)
 
   add_custom_command(
     OUTPUT ${ffig_output_dir}/${module}_c.h ${ffig_output_dir}/${module}_c.cpp
-    COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module} 
-    -o ${ffig_output_dir} -b _c.h.tmpl _c.cpp.tmpl --cflag=-I${_FFIG_INCLUDE_DIR} 
+    COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module}
+    -o ${ffig_output_dir} -b _c.h.tmpl _c.cpp.tmpl --cflag=-I${_FFIG_INCLUDE_DIR}
     COMMAND ${CMAKE_COMMAND} -E copy_if_different ${input} ${ffig_output_dir}/
     DEPENDS ${input} ${FFIG_SOURCE}
     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
@@ -80,8 +80,8 @@ function(ffig_add_java_library)
 
   add_custom_command(
     OUTPUT ${ffig_output_dir}/java/src/${module}/${module}CLibrary.java
-    COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module} 
-    -o ${ffig_output_dir} -b java --cflag=-I${_FFIG_INCLUDE_DIR} 
+    COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module}
+    -o ${ffig_output_dir} -b java --cflag=-I${_FFIG_INCLUDE_DIR}
     DEPENDS ${input} ${FFIG_SOURCE}
     WORKING_DIRECTORY ${FFIG_ROOT}
     COMMENT "Generating java source for ${module}")
@@ -92,7 +92,7 @@ function(ffig_add_java_library)
   add_custom_command(
     OUTPUT ${ffig_output_dir}/${module}.jar
     COMMAND ${Java_JAVAC_EXECUTABLE}
-    -d ${ffig_output_dir}/java/classes/${module} 
+    -d ${ffig_output_dir}/java/classes/${module}
     -cp ${FFIG_JNA_JAR_PATH}
     ${ffig_output_dir}/java/src/${module}/*.java
     COMMAND ${Java_JAR_EXECUTABLE} -cfM ${module}.jar
@@ -116,8 +116,8 @@ function(ffig_add_cpp_library)
 
   add_custom_command(
     OUTPUT ${ffig_output_dir}/${module}_cpp.h
-    COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module} 
-    -o ${ffig_output_dir} -b _cpp.h.tmpl --cflag=-I${_FFIG_INCLUDE_DIR}  
+    COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module}
+    -o ${ffig_output_dir} -b _cpp.h.tmpl --cflag=-I${_FFIG_INCLUDE_DIR}
     DEPENDS ${input} ${FFIG_SOURCE}
     WORKING_DIRECTORY ${FFIG_ROOT}
     COMMENT "Generating C++ bindings for ${module}")
@@ -136,8 +136,8 @@ function(ffig_add_cpp_mocks_library)
 
   add_custom_command(
     OUTPUT ${ffig_output_dir}/${module}_mocks.h
-    COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module} 
-    -o ${ffig_output_dir} -b _mocks.h.tmpl --cflag=-I${_FFIG_INCLUDE_DIR}  
+    COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module}
+    -o ${ffig_output_dir} -b _mocks.h.tmpl --cflag=-I${_FFIG_INCLUDE_DIR}
     DEPENDS ${input} ${FFIG_SOURCE}
     WORKING_DIRECTORY ${FFIG_ROOT}
     COMMENT "Generating C++ mocks for ${module}")
@@ -156,13 +156,13 @@ function(ffig_add_swift_library)
 
   add_custom_command(
     OUTPUT ${ffig_output_dir}/${module}.swift ${ffig_output_dir}/${module}-Bridging-Header.h
-    COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module} 
-    -o ${ffig_output_dir} -b swift --cflag=-I${_FFIG_INCLUDE_DIR}  
+    COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module}
+    -o ${ffig_output_dir} -b swift --cflag=-I${_FFIG_INCLUDE_DIR}
     DEPENDS ${input} ${FFIG_SOURCE}
     WORKING_DIRECTORY ${FFIG_ROOT}
     COMMENT "Generating Swift source for ${module}")
 
-  add_custom_target(${module}.ffig.swift.source ALL 
+  add_custom_target(${module}.ffig.swift.source ALL
     DEPENDS ${ffig_output_dir}/${module}.swift ${ffig_output_dir}/${module}-Bridging-Header.h)
 endfunction()
 
@@ -178,7 +178,7 @@ function(ffig_add_boost_python_library)
   add_custom_command(
     OUTPUT ${ffig_output_dir}/${module}_py.cpp
     COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module}
-    -o ${ffig_output_dir} -b boost_python --cflag=-I${_FFIG_INCLUDE_DIR}  
+    -o ${ffig_output_dir} -b boost_python --cflag=-I${_FFIG_INCLUDE_DIR}
     DEPENDS ${input} ${FFIG_SOURCE}
     WORKING_DIRECTORY ${FFIG_ROOT}
     COMMENT "Generating boost::python source for ${module}")
@@ -198,22 +198,22 @@ function(ffig_add_boost_python_library)
   else()
     set_property(TARGET ${module}_py PROPERTY SUFFIX ".so")
   endif()
-  
-  # FIXME: Do not check dotnet_FOUND. 
+
+  # FIXME: Do not check dotnet_FOUND.
   # Requesting dotnet bindings with no dotnet is user-error.
   if(ffig_add_library_DOTNET AND dotnet_FOUND)
     add_custom_command(
       OUTPUT ${ffig_output_dir}/${module}.net/${module}.cs
       ${ffig_output_dir}/${module}.net/${module}.net.csproj
-      COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module} 
-      -o ${ffig_output_dir} -b dotnet --cflag=-I${_FFIG_INCLUDE_DIR}  
+      COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module}
+      -o ${ffig_output_dir} -b dotnet --cflag=-I${_FFIG_INCLUDE_DIR}
       DEPENDS ${input} ${FFIG_SOURCE}
       WORKING_DIRECTORY ${FFIG_ROOT}
       COMMENT "Generating C# source for ${module}")
 
     add_custom_target(${module}.ffig.net.source ALL
       DEPENDS ${ffig_output_dir}/${module}.net/${module}.cs ${ffig_output_dir}/${module}.net/${module}.net.csproj)
-  
+
     # Invoke dotnet directly as add_dotnet_project contains a copy which does not get ordered correctly.
     # FIXME: Work out why the copy performed by add_dotnet_project is incorrectly ordered on Windows.
     add_custom_command(
@@ -250,8 +250,8 @@ function(ffig_add_python_library)
     OUTPUT ${ffig_output_dir}/${module_lower}/__init__.py
     ${ffig_output_dir}/${module_lower}/_py2.py
     ${ffig_output_dir}/${module_lower}/_py3.py
-    COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module} 
-    -o ${ffig_output_dir} -b python --cflag=-I${_FFIG_INCLUDE_DIR}  
+    COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module}
+    -o ${ffig_output_dir} -b python --cflag=-I${_FFIG_INCLUDE_DIR}
     COMMAND ${PYTHON_EXECUTABLE} -m pycodestyle --ignore=E501 ${ffig_output_dir}/${module_lower}
     DEPENDS ${input} ${FFIG_SOURCE}
     WORKING_DIRECTORY ${FFIG_ROOT}
@@ -274,13 +274,33 @@ function(ffig_add_d_library)
 
   add_custom_command(
     OUTPUT ${ffig_output_dir}/${module}.d
-    COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module} 
-    -o ${ffig_output_dir} -b d.tmpl --cflag=-I${_FFIG_INCLUDE_DIR}  
+    COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module}
+    -o ${ffig_output_dir} -b d.tmpl --cflag=-I${_FFIG_INCLUDE_DIR}
     DEPENDS ${input} ${FFIG_SOURCE}
     WORKING_DIRECTORY ${FFIG_ROOT}
     COMMENT "Generating D bindings for ${module}")
 
   add_custom_target(${module}.ffig.d.source ALL DEPENDS ${ffig_outputs};${ffig_output_dir}/${module}.d)
+endfunction()
+
+function(ffig_add_rust_library)
+  set(options)
+  set(oneValueArgs NAME INPUTS)
+  set(multiValueArgs)
+  cmake_parse_arguments(ffig_add_rust_library "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+  set(module ${ffig_add_rust_library_NAME})
+  set(input ${ffig_add_rust_library_INPUTS})
+  string(TOLOWER "${module}" module_lower)
+
+  add_custom_command(
+    OUTPUT ${ffig_output_dir}/${module}.rs
+    COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module}
+    -o ${ffig_output_dir} -b rs.tmpl --cflag=-I${_FFIG_INCLUDE_DIR}
+    DEPENDS ${input} ${FFIG_SOURCE}
+    WORKING_DIRECTORY ${FFIG_ROOT}
+    COMMENT "Generating Rust bindings for ${module}")
+
+  add_custom_target(${module}.ffig.rust.source ALL DEPENDS ${ffig_outputs};${ffig_output_dir}/${module}.rs)
 endfunction()
 
 function(ffig_add_ruby_library)
@@ -294,8 +314,8 @@ function(ffig_add_ruby_library)
 
   add_custom_command(
     OUTPUT ${ffig_output_dir}/${module}.rb
-    COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module} 
-    -o ${ffig_output_dir} -b ruby --cflag=-I${_FFIG_INCLUDE_DIR}  
+    COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module}
+    -o ${ffig_output_dir} -b ruby --cflag=-I${_FFIG_INCLUDE_DIR}
     DEPENDS ${input} ${FFIG_SOURCE}
     WORKING_DIRECTORY ${FFIG_ROOT}
     COMMENT "Generating Ruby bindings for ${module}")
@@ -314,8 +334,8 @@ function(ffig_add_lua_library)
 
   add_custom_command(
     OUTPUT ${ffig_output_dir}/${module}.lua
-    COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module} 
-    -o ${ffig_output_dir} -b lua --cflag=-I${_FFIG_INCLUDE_DIR}  
+    COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module}
+    -o ${ffig_output_dir} -b lua --cflag=-I${_FFIG_INCLUDE_DIR}
     DEPENDS ${input} ${FFIG_SOURCE}
     WORKING_DIRECTORY ${FFIG_ROOT}
     COMMENT "Generating LuaJIT bindings for ${module}")
@@ -334,8 +354,8 @@ function(ffig_add_go_library)
 
   add_custom_command(
     OUTPUT ${ffig_output_dir}/src/${module}/${module}.go
-    COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module} 
-    -o ${ffig_output_dir} -b go --cflag=-I${_FFIG_INCLUDE_DIR}  
+    COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module}
+    -o ${ffig_output_dir} -b go --cflag=-I${_FFIG_INCLUDE_DIR}
     DEPENDS ${input} ${FFIG_SOURCE}
     WORKING_DIRECTORY ${FFIG_ROOT}
     COMMENT "Generating Go bindings for ${module}")
@@ -375,15 +395,15 @@ function(ffig_add_dotnet_library)
   add_custom_command(
     OUTPUT ${ffig_output_dir}/${module}.net/${module}.cs
     ${ffig_output_dir}/${module}.net/${module}.net.csproj
-    COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module} 
-    -o ${ffig_output_dir} -b dotnet --cflag=-I${_FFIG_INCLUDE_DIR}  
+    COMMAND ${PYTHON_EXECUTABLE} -m ffig -i ${input} -m ${module}
+    -o ${ffig_output_dir} -b dotnet --cflag=-I${_FFIG_INCLUDE_DIR}
     DEPENDS ${input} ${FFIG_SOURCE}
     WORKING_DIRECTORY ${FFIG_ROOT}
     COMMENT "Generating C# source for ${module}")
 
   add_custom_target(${module}.ffig.net.source ALL
     DEPENDS ${ffig_output_dir}/${module}.net/${module}.cs ${ffig_output_dir}/${module}.net/${module}.net.csproj)
-  
+
   # Invoke dotnet directly as add_dotnet_project contains a copy which does not get ordered correctly.
   # FIXME: Work out why the copy performed by add_dotnet_project is incorrectly ordered on Windows.
   add_custom_command(

--- a/ffig/FFIG.py
+++ b/ffig/FFIG.py
@@ -100,7 +100,6 @@ def build_model_from_source(
     """
     cflags = cflags or []
 
-    ffig_include_dir = os.path.join(os.path.dirname(__file__), 'include')
     tu = clang.cindex.TranslationUnit.from_source(
         path_to_source,
         ['-x', 'c++', '-std=c++14', '-stdlib=libc++'] + cflags,

--- a/ffig/templates/rs.tmpl
+++ b/ffig/templates/rs.tmpl
@@ -1,0 +1,12 @@
+{% for class in classes -%}
+pub struct Tree {
+}
+
+impl {{class.name}} {
+{% for method in class.methods %}
+  pub fn {{method.name}}() {
+  }
+
+{% endfor %}
+}
+{% endfor %}

--- a/ffig/templates/rs.tmpl
+++ b/ffig/templates/rs.tmpl
@@ -1,5 +1,5 @@
 {% for class in classes -%}
-pub struct Tree {
+pub struct {{class.name}} {
 }
 
 impl {{class.name}} {

--- a/tests/expected_output/Tree.rs.expected
+++ b/tests/expected_output/Tree.rs.expected
@@ -1,0 +1,17 @@
+pub struct Tree {
+}
+
+impl Tree {
+  pub fn left_subtree() {
+  }
+
+  pub fn right_subtree() {
+  }
+
+  pub fn data() {
+  }
+
+  pub fn set_data() {
+  }
+
+}


### PR DESCRIPTION
Generate a minimal Rust binding consisting of merely the correct class (struct and impl) name, plus methods (fns), in the style of the existing D binding.

Add a test for the minimal Rust binding

Remove trailing whitespace from the two CMake files that were touched

Remove an unused Python variable

Partly addresses #91 

## Possible future work

Extend to generate more Rust code that actually functions