### PR TITLE
Use a named generator for C-API

### DIFF
--- a/cmake/ffig.cmake
+++ b/cmake/ffig.cmake
@@ -38,7 +38,7 @@ function(ffig_add_c_library)
   string(TOLOWER "${module}" module_lower)
 
   set(ffig_output_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
-  set(ffig_invocation "-i;${input};-m;${module};-o;${ffig_output_dir};-b;_c.h.tmpl;_c.cpp.tmpl")
+  set(ffig_invocation "-i;${input};-m;${module};-o;${ffig_output_dir};-b;c")
   set(ffig_outputs "${ffig_output_dir}/${module}_c.h;${ffig_output_dir}/${module}_c.cpp")
 
   add_custom_command(

--- a/ffig.bzl
+++ b/ffig.bzl
@@ -48,7 +48,7 @@ def ffig_c_library(name, module, srcs = None, deps = None, copts = None):
         name = "_" + name + "_c_srcs",
         srcs = srcs,
         module = module,
-        templates = ["_c.h.tmpl", "_c.cpp.tmpl"],
+        templates = ["c"],
         copts = copts,
         genfiles = c_srcs,
     )

--- a/ffig/generators/c.py
+++ b/ffig/generators/c.py
@@ -1,0 +1,30 @@
+# Generator module for Boost-Python.
+
+import ffig.generators
+import os
+
+
+def generator(module_name, binding, api_classes, env, output_dir):
+    outputs = []
+
+    o = os.path.join(output_dir, module_name + '_c.h')
+    ffig.generators.generate_single_output_file(
+        module_name, '_c.h.tmpl', api_classes, env, o)
+    outputs.append(o)
+    
+    o = os.path.join(output_dir, module_name + '_c.cpp')
+    ffig.generators.generate_single_output_file(
+        module_name, '_c.cpp.tmpl', api_classes, env, o)
+    outputs.append(o)
+    
+    return outputs
+
+
+def setup_plugin(context):
+    context.register(
+            generator,
+            [
+                ('c', "C API bindings to be used from other languages' FFI facilities.")
+            ])
+
+


### PR DESCRIPTION
## What does this PR do? 
Internal refactor - Use a named generator for C-API bindings